### PR TITLE
Modify core parts to handle different combinations of target braces that can exist on a single line

### DIFF
--- a/src/packages/core-parts/index.ts
+++ b/src/packages/core-parts/index.ts
@@ -80,9 +80,9 @@ function parseLineByLine(
 }
 
 /**
- * If `Text` exists after `ClosingBrace`, add a line break between `ClosingBrace` and `Text`.
+ * Add a line break after `ClosingBrace`.
  */
-function splitLineStartingWithClosingBrace(lineNodes: LineNode[]) {
+function splitLineContainingClosingBrace(lineNodes: LineNode[]) {
   for (let lineIndex = lineNodes.length - 1; lineIndex >= 0; lineIndex -= 1) {
     const { indentLevel, parts } = lineNodes[lineIndex];
     const temporaryLineNodes: LineNode[] = [];
@@ -120,9 +120,9 @@ function splitLineStartingWithClosingBrace(lineNodes: LineNode[]) {
 }
 
 /**
- * If `Text` exists before `OpeningBrace`, add a line break between `OpeningBrace` and `Text`.
+ * Add a line break before `OpeningBrace`.
  */
-function splitLineEndingWithOpeningBrace(lineNodes: LineNode[]) {
+function splitLineContainingOpeningBrace(lineNodes: LineNode[]) {
   for (let lineIndex = lineNodes.length - 1; lineIndex >= 0; lineIndex -= 1) {
     const { indentLevel, parts } = lineNodes[lineIndex];
     const temporaryLineNodes: LineNode[] = [];
@@ -199,10 +199,10 @@ export function parseLineByLineAndAssemble(
 
   const lineNodes = parseLineByLine(formattedText, indentUnit, targetBraceNodes);
 
-  splitLineStartingWithClosingBrace(lineNodes);
+  splitLineContainingClosingBrace(lineNodes);
 
   if (options.braceStyle === 'allman') {
-    splitLineEndingWithOpeningBrace(lineNodes);
+    splitLineContainingOpeningBrace(lineNodes);
   }
 
   return assembleLine(lineNodes, indentUnit);

--- a/tests/v2-test/astro/issue-25/1tbs.test.ts
+++ b/tests/v2-test/astro/issue-25/1tbs.test.ts
@@ -43,6 +43,34 @@ const foo = {
 `,
   },
   {
+    name: 'destructuring assignment with default value',
+    input: `
+---
+const renderComponent = ({handleSubmit = () => {}, errors}) => {
+  return null;
+};
+---
+
+<script>
+const renderComponent = ({handleSubmit = () => {}, errors}) => {
+  return null;
+};
+</script>
+`,
+    output: `---
+const renderComponent = ({ handleSubmit = () => {}, errors }) => {
+  return null;
+};
+---
+
+<script>
+  const renderComponent = ({ handleSubmit = () => {}, errors }) => {
+    return null;
+  };
+</script>
+`,
+  },
+  {
     name: 'class declaration (1) - empty method',
     input: `
 ---

--- a/tests/v2-test/astro/issue-25/allman.test.ts
+++ b/tests/v2-test/astro/issue-25/allman.test.ts
@@ -43,6 +43,38 @@ const foo = {
 `,
   },
   {
+    name: 'destructuring assignment with default value',
+    input: `
+---
+const renderComponent = ({handleSubmit = () => {}, errors}) => {
+  return null;
+};
+---
+
+<script>
+const renderComponent = ({handleSubmit = () => {}, errors}) => {
+  return null;
+};
+</script>
+`,
+    output: `---
+const renderComponent = ({ handleSubmit = () =>
+{}, errors }) =>
+{
+  return null;
+};
+---
+
+<script>
+  const renderComponent = ({ handleSubmit = () =>
+  {}, errors }) =>
+  {
+    return null;
+  };
+</script>
+`,
+  },
+  {
     name: 'class declaration (1) - empty method',
     input: `
 ---

--- a/tests/v2-test/astro/issue-25/stroustrup.test.ts
+++ b/tests/v2-test/astro/issue-25/stroustrup.test.ts
@@ -43,6 +43,34 @@ const foo = {
 `,
   },
   {
+    name: 'destructuring assignment with default value',
+    input: `
+---
+const renderComponent = ({handleSubmit = () => {}, errors}) => {
+  return null;
+};
+---
+
+<script>
+const renderComponent = ({handleSubmit = () => {}, errors}) => {
+  return null;
+};
+</script>
+`,
+    output: `---
+const renderComponent = ({ handleSubmit = () => {}, errors }) => {
+  return null;
+};
+---
+
+<script>
+  const renderComponent = ({ handleSubmit = () => {}, errors }) => {
+    return null;
+  };
+</script>
+`,
+  },
+  {
     name: 'class declaration (1) - empty method',
     input: `
 ---

--- a/tests/v2-test/babel/issue-25/1tbs.test.ts
+++ b/tests/v2-test/babel/issue-25/1tbs.test.ts
@@ -28,6 +28,30 @@ const foo = {
 `,
   },
   {
+    name: 'destructuring assignment with default value',
+    input: `
+const renderComponent = ({handleSubmit = () => {}, errors}) => {
+  const ref = React.createRef();
+
+  return render(
+    <StyleErrorsContextProvider initialState={errors}>
+      <PublishButton formRef={ref} handleSubmit={handleSubmit} />
+    </StyleErrorsContextProvider>
+  );
+};
+`,
+    output: `const renderComponent = ({ handleSubmit = () => {}, errors }) => {
+  const ref = React.createRef();
+
+  return render(
+    <StyleErrorsContextProvider initialState={errors}>
+      <PublishButton formRef={ref} handleSubmit={handleSubmit} />
+    </StyleErrorsContextProvider>,
+  );
+};
+`,
+  },
+  {
     name: 'class declaration (1) - empty method',
     input: `
 class BaseQueue {

--- a/tests/v2-test/babel/issue-25/allman.test.ts
+++ b/tests/v2-test/babel/issue-25/allman.test.ts
@@ -28,6 +28,32 @@ const foo = {
 `,
   },
   {
+    name: 'destructuring assignment with default value',
+    input: `
+const renderComponent = ({handleSubmit = () => {}, errors}) => {
+  const ref = React.createRef();
+
+  return render(
+    <StyleErrorsContextProvider initialState={errors}>
+      <PublishButton formRef={ref} handleSubmit={handleSubmit} />
+    </StyleErrorsContextProvider>
+  );
+};
+`,
+    output: `const renderComponent = ({ handleSubmit = () =>
+{}, errors }) =>
+{
+  const ref = React.createRef();
+
+  return render(
+    <StyleErrorsContextProvider initialState={errors}>
+      <PublishButton formRef={ref} handleSubmit={handleSubmit} />
+    </StyleErrorsContextProvider>,
+  );
+};
+`,
+  },
+  {
     name: 'class declaration (1) - empty method',
     input: `
 class BaseQueue {

--- a/tests/v2-test/babel/issue-25/stroustrup.test.ts
+++ b/tests/v2-test/babel/issue-25/stroustrup.test.ts
@@ -28,6 +28,30 @@ const foo = {
 `,
   },
   {
+    name: 'destructuring assignment with default value',
+    input: `
+const renderComponent = ({handleSubmit = () => {}, errors}) => {
+  const ref = React.createRef();
+
+  return render(
+    <StyleErrorsContextProvider initialState={errors}>
+      <PublishButton formRef={ref} handleSubmit={handleSubmit} />
+    </StyleErrorsContextProvider>
+  );
+};
+`,
+    output: `const renderComponent = ({ handleSubmit = () => {}, errors }) => {
+  const ref = React.createRef();
+
+  return render(
+    <StyleErrorsContextProvider initialState={errors}>
+      <PublishButton formRef={ref} handleSubmit={handleSubmit} />
+    </StyleErrorsContextProvider>,
+  );
+};
+`,
+  },
+  {
     name: 'class declaration (1) - empty method',
     input: `
 class BaseQueue {

--- a/tests/v2-test/typescript/issue-25/1tbs.test.ts
+++ b/tests/v2-test/typescript/issue-25/1tbs.test.ts
@@ -27,6 +27,30 @@ const foo = {
 `,
   },
   {
+    name: 'destructuring assignment with default value',
+    input: `
+const renderComponent = ({handleSubmit = () => {}, errors}) => {
+  const ref = React.createRef();
+
+  return render(
+    <StyleErrorsContextProvider initialState={errors}>
+      <PublishButton formRef={ref} handleSubmit={handleSubmit} />
+    </StyleErrorsContextProvider>
+  );
+};
+`,
+    output: `const renderComponent = ({ handleSubmit = () => {}, errors }) => {
+  const ref = React.createRef();
+
+  return render(
+    <StyleErrorsContextProvider initialState={errors}>
+      <PublishButton formRef={ref} handleSubmit={handleSubmit} />
+    </StyleErrorsContextProvider>,
+  );
+};
+`,
+  },
+  {
     name: 'class declaration (1) - empty method',
     input: `
 class BaseQueue {

--- a/tests/v2-test/typescript/issue-25/allman.test.ts
+++ b/tests/v2-test/typescript/issue-25/allman.test.ts
@@ -27,6 +27,32 @@ const foo = {
 `,
   },
   {
+    name: 'destructuring assignment with default value',
+    input: `
+const renderComponent = ({handleSubmit = () => {}, errors}) => {
+  const ref = React.createRef();
+
+  return render(
+    <StyleErrorsContextProvider initialState={errors}>
+      <PublishButton formRef={ref} handleSubmit={handleSubmit} />
+    </StyleErrorsContextProvider>
+  );
+};
+`,
+    output: `const renderComponent = ({ handleSubmit = () =>
+{}, errors }) =>
+{
+  const ref = React.createRef();
+
+  return render(
+    <StyleErrorsContextProvider initialState={errors}>
+      <PublishButton formRef={ref} handleSubmit={handleSubmit} />
+    </StyleErrorsContextProvider>,
+  );
+};
+`,
+  },
+  {
     name: 'class declaration (1) - empty method',
     input: `
 class BaseQueue {

--- a/tests/v2-test/typescript/issue-25/stroustrup.test.ts
+++ b/tests/v2-test/typescript/issue-25/stroustrup.test.ts
@@ -27,6 +27,30 @@ const foo = {
 `,
   },
   {
+    name: 'destructuring assignment with default value',
+    input: `
+const renderComponent = ({handleSubmit = () => {}, errors}) => {
+  const ref = React.createRef();
+
+  return render(
+    <StyleErrorsContextProvider initialState={errors}>
+      <PublishButton formRef={ref} handleSubmit={handleSubmit} />
+    </StyleErrorsContextProvider>
+  );
+};
+`,
+    output: `const renderComponent = ({ handleSubmit = () => {}, errors }) => {
+  const ref = React.createRef();
+
+  return render(
+    <StyleErrorsContextProvider initialState={errors}>
+      <PublishButton formRef={ref} handleSubmit={handleSubmit} />
+    </StyleErrorsContextProvider>,
+  );
+};
+`,
+  },
+  {
     name: 'class declaration (1) - empty method',
     input: `
 class BaseQueue {

--- a/tests/v2-test/vue/issue-25/1tbs.test.ts
+++ b/tests/v2-test/vue/issue-25/1tbs.test.ts
@@ -59,6 +59,50 @@ const foo = {
 `,
   },
   {
+    name: 'destructuring assignment with default value',
+    input: `
+<script setup lang="ts">
+const renderComponent = ({handleSubmit = () => {}, errors}) => {
+  return null;
+};
+</script>
+
+<template>
+  <button
+    type="button"
+    @click="() => {
+const renderComponent = ({handleSubmit = () => {}, errors}) => {
+  return null;
+};
+    }"
+  >
+    Click Me
+  </button>
+</template>
+`,
+    output: `<script setup lang="ts">
+const renderComponent = ({ handleSubmit = () => {}, errors }) => {
+  return null;
+};
+</script>
+
+<template>
+  <button
+    type="button"
+    @click="
+      () => {
+        const renderComponent = ({ handleSubmit = () => {}, errors }) => {
+          return null;
+        };
+      }
+    "
+  >
+    Click Me
+  </button>
+</template>
+`,
+  },
+  {
     name: 'class declaration (1) - empty method',
     input: `
 <script setup lang="ts">

--- a/tests/v2-test/vue/issue-25/allman.test.ts
+++ b/tests/v2-test/vue/issue-25/allman.test.ts
@@ -60,6 +60,55 @@ const foo = {
 `,
   },
   {
+    name: 'destructuring assignment with default value',
+    input: `
+<script setup lang="ts">
+const renderComponent = ({handleSubmit = () => {}, errors}) => {
+  return null;
+};
+</script>
+
+<template>
+  <button
+    type="button"
+    @click="() => {
+const renderComponent = ({handleSubmit = () => {}, errors}) => {
+  return null;
+};
+    }"
+  >
+    Click Me
+  </button>
+</template>
+`,
+    output: `<script setup lang="ts">
+const renderComponent = ({ handleSubmit = () =>
+{}, errors }) =>
+{
+  return null;
+};
+</script>
+
+<template>
+  <button
+    type="button"
+    @click="
+      () =>
+      {
+        const renderComponent = ({ handleSubmit = () =>
+        {}, errors }) =>
+        {
+          return null;
+        };
+      }
+    "
+  >
+    Click Me
+  </button>
+</template>
+`,
+  },
+  {
     name: 'class declaration (1) - empty method',
     input: `
 <script setup lang="ts">

--- a/tests/v2-test/vue/issue-25/stroustrup.test.ts
+++ b/tests/v2-test/vue/issue-25/stroustrup.test.ts
@@ -59,6 +59,50 @@ const foo = {
 `,
   },
   {
+    name: 'destructuring assignment with default value',
+    input: `
+<script setup lang="ts">
+const renderComponent = ({handleSubmit = () => {}, errors}) => {
+  return null;
+};
+</script>
+
+<template>
+  <button
+    type="button"
+    @click="() => {
+const renderComponent = ({handleSubmit = () => {}, errors}) => {
+  return null;
+};
+    }"
+  >
+    Click Me
+  </button>
+</template>
+`,
+    output: `<script setup lang="ts">
+const renderComponent = ({ handleSubmit = () => {}, errors }) => {
+  return null;
+};
+</script>
+
+<template>
+  <button
+    type="button"
+    @click="
+      () => {
+        const renderComponent = ({ handleSubmit = () => {}, errors }) => {
+          return null;
+        };
+      }
+    "
+  >
+    Click Me
+  </button>
+</template>
+`,
+  },
+  {
     name: 'class declaration (1) - empty method',
     input: `
 <script setup lang="ts">

--- a/tests/v3-test/astro/issue-25/1tbs.test.ts
+++ b/tests/v3-test/astro/issue-25/1tbs.test.ts
@@ -43,6 +43,34 @@ const foo = {
 `,
   },
   {
+    name: 'destructuring assignment with default value',
+    input: `
+---
+const renderComponent = ({handleSubmit = () => {}, errors}) => {
+  return null;
+};
+---
+
+<script>
+const renderComponent = ({handleSubmit = () => {}, errors}) => {
+  return null;
+};
+</script>
+`,
+    output: `---
+const renderComponent = ({ handleSubmit = () => {}, errors }) => {
+  return null;
+};
+---
+
+<script>
+  const renderComponent = ({ handleSubmit = () => {}, errors }) => {
+    return null;
+  };
+</script>
+`,
+  },
+  {
     name: 'class declaration (1) - empty method',
     input: `
 ---

--- a/tests/v3-test/astro/issue-25/allman.test.ts
+++ b/tests/v3-test/astro/issue-25/allman.test.ts
@@ -43,6 +43,38 @@ const foo = {
 `,
   },
   {
+    name: 'destructuring assignment with default value',
+    input: `
+---
+const renderComponent = ({handleSubmit = () => {}, errors}) => {
+  return null;
+};
+---
+
+<script>
+const renderComponent = ({handleSubmit = () => {}, errors}) => {
+  return null;
+};
+</script>
+`,
+    output: `---
+const renderComponent = ({ handleSubmit = () =>
+{}, errors }) =>
+{
+  return null;
+};
+---
+
+<script>
+  const renderComponent = ({ handleSubmit = () =>
+  {}, errors }) =>
+  {
+    return null;
+  };
+</script>
+`,
+  },
+  {
     name: 'class declaration (1) - empty method',
     input: `
 ---

--- a/tests/v3-test/astro/issue-25/stroustrup.test.ts
+++ b/tests/v3-test/astro/issue-25/stroustrup.test.ts
@@ -43,6 +43,34 @@ const foo = {
 `,
   },
   {
+    name: 'destructuring assignment with default value',
+    input: `
+---
+const renderComponent = ({handleSubmit = () => {}, errors}) => {
+  return null;
+};
+---
+
+<script>
+const renderComponent = ({handleSubmit = () => {}, errors}) => {
+  return null;
+};
+</script>
+`,
+    output: `---
+const renderComponent = ({ handleSubmit = () => {}, errors }) => {
+  return null;
+};
+---
+
+<script>
+  const renderComponent = ({ handleSubmit = () => {}, errors }) => {
+    return null;
+  };
+</script>
+`,
+  },
+  {
     name: 'class declaration (1) - empty method',
     input: `
 ---

--- a/tests/v3-test/babel/issue-25/1tbs.test.ts
+++ b/tests/v3-test/babel/issue-25/1tbs.test.ts
@@ -28,6 +28,30 @@ const foo = {
 `,
   },
   {
+    name: 'destructuring assignment with default value',
+    input: `
+const renderComponent = ({handleSubmit = () => {}, errors}) => {
+  const ref = React.createRef();
+
+  return render(
+    <StyleErrorsContextProvider initialState={errors}>
+      <PublishButton formRef={ref} handleSubmit={handleSubmit} />
+    </StyleErrorsContextProvider>
+  );
+};
+`,
+    output: `const renderComponent = ({ handleSubmit = () => {}, errors }) => {
+  const ref = React.createRef();
+
+  return render(
+    <StyleErrorsContextProvider initialState={errors}>
+      <PublishButton formRef={ref} handleSubmit={handleSubmit} />
+    </StyleErrorsContextProvider>,
+  );
+};
+`,
+  },
+  {
     name: 'class declaration (1) - empty method',
     input: `
 class BaseQueue {

--- a/tests/v3-test/babel/issue-25/allman.test.ts
+++ b/tests/v3-test/babel/issue-25/allman.test.ts
@@ -28,6 +28,32 @@ const foo = {
 `,
   },
   {
+    name: 'destructuring assignment with default value',
+    input: `
+const renderComponent = ({handleSubmit = () => {}, errors}) => {
+  const ref = React.createRef();
+
+  return render(
+    <StyleErrorsContextProvider initialState={errors}>
+      <PublishButton formRef={ref} handleSubmit={handleSubmit} />
+    </StyleErrorsContextProvider>
+  );
+};
+`,
+    output: `const renderComponent = ({ handleSubmit = () =>
+{}, errors }) =>
+{
+  const ref = React.createRef();
+
+  return render(
+    <StyleErrorsContextProvider initialState={errors}>
+      <PublishButton formRef={ref} handleSubmit={handleSubmit} />
+    </StyleErrorsContextProvider>,
+  );
+};
+`,
+  },
+  {
     name: 'class declaration (1) - empty method',
     input: `
 class BaseQueue {

--- a/tests/v3-test/babel/issue-25/stroustrup.test.ts
+++ b/tests/v3-test/babel/issue-25/stroustrup.test.ts
@@ -28,6 +28,30 @@ const foo = {
 `,
   },
   {
+    name: 'destructuring assignment with default value',
+    input: `
+const renderComponent = ({handleSubmit = () => {}, errors}) => {
+  const ref = React.createRef();
+
+  return render(
+    <StyleErrorsContextProvider initialState={errors}>
+      <PublishButton formRef={ref} handleSubmit={handleSubmit} />
+    </StyleErrorsContextProvider>
+  );
+};
+`,
+    output: `const renderComponent = ({ handleSubmit = () => {}, errors }) => {
+  const ref = React.createRef();
+
+  return render(
+    <StyleErrorsContextProvider initialState={errors}>
+      <PublishButton formRef={ref} handleSubmit={handleSubmit} />
+    </StyleErrorsContextProvider>,
+  );
+};
+`,
+  },
+  {
     name: 'class declaration (1) - empty method',
     input: `
 class BaseQueue {

--- a/tests/v3-test/typescript/issue-25/1tbs.test.ts
+++ b/tests/v3-test/typescript/issue-25/1tbs.test.ts
@@ -27,6 +27,30 @@ const foo = {
 `,
   },
   {
+    name: 'destructuring assignment with default value',
+    input: `
+const renderComponent = ({handleSubmit = () => {}, errors}) => {
+  const ref = React.createRef();
+
+  return render(
+    <StyleErrorsContextProvider initialState={errors}>
+      <PublishButton formRef={ref} handleSubmit={handleSubmit} />
+    </StyleErrorsContextProvider>
+  );
+};
+`,
+    output: `const renderComponent = ({ handleSubmit = () => {}, errors }) => {
+  const ref = React.createRef();
+
+  return render(
+    <StyleErrorsContextProvider initialState={errors}>
+      <PublishButton formRef={ref} handleSubmit={handleSubmit} />
+    </StyleErrorsContextProvider>,
+  );
+};
+`,
+  },
+  {
     name: 'class declaration (1) - empty method',
     input: `
 class BaseQueue {

--- a/tests/v3-test/typescript/issue-25/allman.test.ts
+++ b/tests/v3-test/typescript/issue-25/allman.test.ts
@@ -27,6 +27,32 @@ const foo = {
 `,
   },
   {
+    name: 'destructuring assignment with default value',
+    input: `
+const renderComponent = ({handleSubmit = () => {}, errors}) => {
+  const ref = React.createRef();
+
+  return render(
+    <StyleErrorsContextProvider initialState={errors}>
+      <PublishButton formRef={ref} handleSubmit={handleSubmit} />
+    </StyleErrorsContextProvider>
+  );
+};
+`,
+    output: `const renderComponent = ({ handleSubmit = () =>
+{}, errors }) =>
+{
+  const ref = React.createRef();
+
+  return render(
+    <StyleErrorsContextProvider initialState={errors}>
+      <PublishButton formRef={ref} handleSubmit={handleSubmit} />
+    </StyleErrorsContextProvider>,
+  );
+};
+`,
+  },
+  {
     name: 'class declaration (1) - empty method',
     input: `
 class BaseQueue {

--- a/tests/v3-test/typescript/issue-25/stroustrup.test.ts
+++ b/tests/v3-test/typescript/issue-25/stroustrup.test.ts
@@ -27,6 +27,30 @@ const foo = {
 `,
   },
   {
+    name: 'destructuring assignment with default value',
+    input: `
+const renderComponent = ({handleSubmit = () => {}, errors}) => {
+  const ref = React.createRef();
+
+  return render(
+    <StyleErrorsContextProvider initialState={errors}>
+      <PublishButton formRef={ref} handleSubmit={handleSubmit} />
+    </StyleErrorsContextProvider>
+  );
+};
+`,
+    output: `const renderComponent = ({ handleSubmit = () => {}, errors }) => {
+  const ref = React.createRef();
+
+  return render(
+    <StyleErrorsContextProvider initialState={errors}>
+      <PublishButton formRef={ref} handleSubmit={handleSubmit} />
+    </StyleErrorsContextProvider>,
+  );
+};
+`,
+  },
+  {
     name: 'class declaration (1) - empty method',
     input: `
 class BaseQueue {

--- a/tests/v3-test/vue/issue-25/1tbs.test.ts
+++ b/tests/v3-test/vue/issue-25/1tbs.test.ts
@@ -59,6 +59,50 @@ const foo = {
 `,
   },
   {
+    name: 'destructuring assignment with default value',
+    input: `
+<script setup lang="ts">
+const renderComponent = ({handleSubmit = () => {}, errors}) => {
+  return null;
+};
+</script>
+
+<template>
+  <button
+    type="button"
+    @click="() => {
+const renderComponent = ({handleSubmit = () => {}, errors}) => {
+  return null;
+};
+    }"
+  >
+    Click Me
+  </button>
+</template>
+`,
+    output: `<script setup lang="ts">
+const renderComponent = ({ handleSubmit = () => {}, errors }) => {
+  return null;
+};
+</script>
+
+<template>
+  <button
+    type="button"
+    @click="
+      () => {
+        const renderComponent = ({ handleSubmit = () => {}, errors }) => {
+          return null;
+        };
+      }
+    "
+  >
+    Click Me
+  </button>
+</template>
+`,
+  },
+  {
     name: 'class declaration (1) - empty method',
     input: `
 <script setup lang="ts">

--- a/tests/v3-test/vue/issue-25/allman.test.ts
+++ b/tests/v3-test/vue/issue-25/allman.test.ts
@@ -60,6 +60,55 @@ const foo = {
 `,
   },
   {
+    name: 'destructuring assignment with default value',
+    input: `
+<script setup lang="ts">
+const renderComponent = ({handleSubmit = () => {}, errors}) => {
+  return null;
+};
+</script>
+
+<template>
+  <button
+    type="button"
+    @click="() => {
+const renderComponent = ({handleSubmit = () => {}, errors}) => {
+  return null;
+};
+    }"
+  >
+    Click Me
+  </button>
+</template>
+`,
+    output: `<script setup lang="ts">
+const renderComponent = ({ handleSubmit = () =>
+{}, errors }) =>
+{
+  return null;
+};
+</script>
+
+<template>
+  <button
+    type="button"
+    @click="
+      () =>
+      {
+        const renderComponent = ({ handleSubmit = () =>
+        {}, errors }) =>
+        {
+          return null;
+        };
+      }
+    "
+  >
+    Click Me
+  </button>
+</template>
+`,
+  },
+  {
     name: 'class declaration (1) - empty method',
     input: `
 <script setup lang="ts">

--- a/tests/v3-test/vue/issue-25/stroustrup.test.ts
+++ b/tests/v3-test/vue/issue-25/stroustrup.test.ts
@@ -59,6 +59,50 @@ const foo = {
 `,
   },
   {
+    name: 'destructuring assignment with default value',
+    input: `
+<script setup lang="ts">
+const renderComponent = ({handleSubmit = () => {}, errors}) => {
+  return null;
+};
+</script>
+
+<template>
+  <button
+    type="button"
+    @click="() => {
+const renderComponent = ({handleSubmit = () => {}, errors}) => {
+  return null;
+};
+    }"
+  >
+    Click Me
+  </button>
+</template>
+`,
+    output: `<script setup lang="ts">
+const renderComponent = ({ handleSubmit = () => {}, errors }) => {
+  return null;
+};
+</script>
+
+<template>
+  <button
+    type="button"
+    @click="
+      () => {
+        const renderComponent = ({ handleSubmit = () => {}, errors }) => {
+          return null;
+        };
+      }
+    "
+  >
+    Click Me
+  </button>
+</template>
+`,
+  },
+  {
     name: 'class declaration (1) - empty method',
     input: `
 <script setup lang="ts">


### PR DESCRIPTION
This PR closes #25 again.

This plugin is theoretically equivalent to applying ESLint formatting (`brace-style` only) after applying Prettier formatting.

As a result of applying the Prettier format, I naively assumed that if the target brace was present on a line, it would be in only one form: "starts with a closing brace", "ends with an opening brace", or both.

However, in the process of solving #25, a case where two opening braces could exist in one line was discovered, so the logic of the core part was corrected.