### PR TITLE
When `braceStyle` is `allman`, the opening brace of a switch statement case block also breaks into new lines.

### DIFF
--- a/src/packages/core-parts/finder.ts
+++ b/src/packages/core-parts/finder.ts
@@ -103,7 +103,7 @@ export function findTargetBraceNodes(ast: any): BraceNode[] {
         nonCommentNodes.push(currentASTNode);
 
         braceNodes.push({
-          type: parentNode?.type === 'SwitchCase' ? BraceType.OBNT : BraceType.OB,
+          type: BraceType.OB,
           range: [currentNodeRangeStart, currentNodeRangeStart + 1],
         });
         braceNodes.push({
@@ -907,7 +907,7 @@ export function findTargetBraceNodesForSvelte(ast: any): BraceNode[] {
         nonCommentNodes.push(currentASTNode);
 
         braceNodes.push({
-          type: parentNode?.type === 'SwitchCase' ? BraceType.OBNT : BraceType.OB,
+          type: BraceType.OB,
           range: [currentNodeRangeStart, currentNodeRangeStart + 1],
         });
         braceNodes.push({

--- a/tests/v2-test/angular/issue-25/__snapshots__/allman.test.ts.snap
+++ b/tests/v2-test/angular/issue-25/__snapshots__/allman.test.ts.snap
@@ -103,11 +103,14 @@ exports[`switch (2) - case with block 1`] = `
 "<script lang="ts">
   switch (action)
   {
-    case "say_hello": {
+    case "say_hello":
+    {
     }
-    case "say_hi": {
+    case "say_hi":
+    {
     }
-    default: {
+    default:
+    {
     }
   }
 </script>

--- a/tests/v2-test/angular/switch/__snapshots__/allman.test.ts.snap
+++ b/tests/v2-test/angular/switch/__snapshots__/allman.test.ts.snap
@@ -22,17 +22,20 @@ exports[`switch (2) - case with block 1`] = `
 "<script lang="ts">
   switch (action)
   {
-    case "say_hello": {
+    case "say_hello":
+    {
       const message = "hello";
       console.log(message);
       break;
     }
-    case "say_hi": {
+    case "say_hi":
+    {
       const message = "hi";
       console.log(message);
       break;
     }
-    default: {
+    default:
+    {
       console.log("Empty action received.");
     }
   }

--- a/tests/v2-test/astro/issue-25/allman.test.ts
+++ b/tests/v2-test/astro/issue-25/allman.test.ts
@@ -296,11 +296,14 @@ switch (action) {
     output: `---
 switch (action)
 {
-  case "say_hello": {
+  case "say_hello":
+  {
   }
-  case "say_hi": {
+  case "say_hi":
+  {
   }
-  default: {
+  default:
+  {
   }
 }
 ---
@@ -308,11 +311,14 @@ switch (action)
 <script>
   switch (action)
   {
-    case "say_hello": {
+    case "say_hello":
+    {
     }
-    case "say_hi": {
+    case "say_hi":
+    {
     }
-    default: {
+    default:
+    {
     }
   }
 </script>

--- a/tests/v2-test/astro/switch/allman.test.ts
+++ b/tests/v2-test/astro/switch/allman.test.ts
@@ -118,17 +118,20 @@ switch (action) {
     output: `---
 switch (action)
 {
-  case "say_hello": {
+  case "say_hello":
+  {
     const message = "hello";
     console.log(message);
     break;
   }
-  case "say_hi": {
+  case "say_hi":
+  {
     const message = "hi";
     console.log(message);
     break;
   }
-  default: {
+  default:
+  {
     console.log("Empty action received.");
   }
 }
@@ -137,17 +140,20 @@ switch (action)
 <script>
   switch (action)
   {
-    case "say_hello": {
+    case "say_hello":
+    {
       const message = "hello";
       console.log(message);
       break;
     }
-    case "say_hi": {
+    case "say_hi":
+    {
       const message = "hi";
       console.log(message);
       break;
     }
-    default: {
+    default:
+    {
       console.log("Empty action received.");
     }
   }

--- a/tests/v2-test/babel/issue-25/allman.test.ts
+++ b/tests/v2-test/babel/issue-25/allman.test.ts
@@ -152,11 +152,14 @@ switch (action) {
 `,
     output: `switch (action)
 {
-  case "say_hello": {
+  case "say_hello":
+  {
   }
-  case "say_hi": {
+  case "say_hi":
+  {
   }
-  default: {
+  default:
+  {
   }
 }
 `,

--- a/tests/v2-test/babel/switch/allman.test.ts
+++ b/tests/v2-test/babel/switch/allman.test.ts
@@ -65,17 +65,20 @@ switch (action) {
 `,
     output: `switch (action)
 {
-  case "say_hello": {
+  case "say_hello":
+  {
     const message = "hello";
     console.log(message);
     break;
   }
-  case "say_hi": {
+  case "say_hi":
+  {
     const message = "hi";
     console.log(message);
     break;
   }
-  default: {
+  default:
+  {
     console.log("Empty action received.");
   }
 }

--- a/tests/v2-test/html/issue-25/__snapshots__/allman.test.ts.snap
+++ b/tests/v2-test/html/issue-25/__snapshots__/allman.test.ts.snap
@@ -103,11 +103,14 @@ exports[`switch (2) - case with block 1`] = `
 "<script lang="ts">
   switch (action)
   {
-    case "say_hello": {
+    case "say_hello":
+    {
     }
-    case "say_hi": {
+    case "say_hi":
+    {
     }
-    default: {
+    default:
+    {
     }
   }
 </script>

--- a/tests/v2-test/html/switch/__snapshots__/allman.test.ts.snap
+++ b/tests/v2-test/html/switch/__snapshots__/allman.test.ts.snap
@@ -22,17 +22,20 @@ exports[`switch (2) - case with block 1`] = `
 "<script lang="ts">
   switch (action)
   {
-    case "say_hello": {
+    case "say_hello":
+    {
       const message = "hello";
       console.log(message);
       break;
     }
-    case "say_hi": {
+    case "say_hi":
+    {
       const message = "hi";
       console.log(message);
       break;
     }
-    default: {
+    default:
+    {
       console.log("Empty action received.");
     }
   }

--- a/tests/v2-test/svelte/issue-25/__snapshots__/allman.test.ts.snap
+++ b/tests/v2-test/svelte/issue-25/__snapshots__/allman.test.ts.snap
@@ -247,11 +247,14 @@ exports[`switch (2) - case with block 1`] = `
 "<script lang="ts">
   switch (action)
   {
-    case "say_hello": {
+    case "say_hello":
+    {
     }
-    case "say_hi": {
+    case "say_hi":
+    {
     }
-    default: {
+    default:
+    {
     }
   }
 </script>
@@ -263,11 +266,14 @@ exports[`switch (2) - case with block 1`] = `
     {
       switch (action)
       {
-        case "say_hello": {
+        case "say_hello":
+        {
         }
-        case "say_hi": {
+        case "say_hi":
+        {
         }
-        default: {
+        default:
+        {
         }
       }
     }}

--- a/tests/v2-test/svelte/switch/__snapshots__/allman.test.ts.snap
+++ b/tests/v2-test/svelte/switch/__snapshots__/allman.test.ts.snap
@@ -45,17 +45,20 @@ exports[`switch (2) - case with block 1`] = `
 "<script lang="ts">
   switch (action)
   {
-    case "say_hello": {
+    case "say_hello":
+    {
       const message = "hello";
       console.log(message);
       break;
     }
-    case "say_hi": {
+    case "say_hi":
+    {
       const message = "hi";
       console.log(message);
       break;
     }
-    default: {
+    default:
+    {
       console.log("Empty action received.");
     }
   }
@@ -68,17 +71,20 @@ exports[`switch (2) - case with block 1`] = `
     {
       switch (action)
       {
-        case "say_hello": {
+        case "say_hello":
+        {
           const message = "hello";
           console.log(message);
           break;
         }
-        case "say_hi": {
+        case "say_hi":
+        {
           const message = "hi";
           console.log(message);
           break;
         }
-        default: {
+        default:
+        {
           console.log("Empty action received.");
         }
       }

--- a/tests/v2-test/typescript/issue-25/allman.test.ts
+++ b/tests/v2-test/typescript/issue-25/allman.test.ts
@@ -187,11 +187,14 @@ switch (action) {
 `,
     output: `switch (action)
 {
-  case "say_hello": {
+  case "say_hello":
+  {
   }
-  case "say_hi": {
+  case "say_hi":
+  {
   }
-  default: {
+  default:
+  {
   }
 }
 `,

--- a/tests/v2-test/typescript/switch/allman.test.ts
+++ b/tests/v2-test/typescript/switch/allman.test.ts
@@ -64,17 +64,20 @@ switch (action) {
 `,
     output: `switch (action)
 {
-  case "say_hello": {
+  case "say_hello":
+  {
     const message = "hello";
     console.log(message);
     break;
   }
-  case "say_hi": {
+  case "say_hi":
+  {
     const message = "hi";
     console.log(message);
     break;
   }
-  default: {
+  default:
+  {
     console.log("Empty action received.");
   }
 }

--- a/tests/v2-test/vue/issue-25/allman.test.ts
+++ b/tests/v2-test/vue/issue-25/allman.test.ts
@@ -439,11 +439,14 @@ switch (action) {
     output: `<script setup lang="ts">
 switch (action)
 {
-  case "say_hello": {
+  case "say_hello":
+  {
   }
-  case "say_hi": {
+  case "say_hi":
+  {
   }
-  default: {
+  default:
+  {
   }
 }
 </script>
@@ -456,11 +459,14 @@ switch (action)
       {
         switch (action)
         {
-          case 'say_hello': {
+          case 'say_hello':
+          {
           }
-          case 'say_hi': {
+          case 'say_hi':
+          {
           }
-          default: {
+          default:
+          {
           }
         }
       }

--- a/tests/v2-test/vue/switch/allman.test.ts
+++ b/tests/v2-test/vue/switch/allman.test.ts
@@ -142,17 +142,20 @@ switch (action) {
     output: `<script setup lang="ts">
 switch (action)
 {
-  case "say_hello": {
+  case "say_hello":
+  {
     const message = "hello";
     console.log(message);
     break;
   }
-  case "say_hi": {
+  case "say_hi":
+  {
     const message = "hi";
     console.log(message);
     break;
   }
-  default: {
+  default:
+  {
     console.log("Empty action received.");
   }
 }
@@ -166,17 +169,20 @@ switch (action)
       {
         switch (action)
         {
-          case 'say_hello': {
+          case 'say_hello':
+          {
             const message = 'hello';
             console.log(message);
             break;
           }
-          case 'say_hi': {
+          case 'say_hi':
+          {
             const message = 'hi';
             console.log(message);
             break;
           }
-          default: {
+          default:
+          {
             console.log('Empty action received.');
           }
         }

--- a/tests/v3-test/angular/issue-25/__snapshots__/allman.test.ts.snap
+++ b/tests/v3-test/angular/issue-25/__snapshots__/allman.test.ts.snap
@@ -103,11 +103,14 @@ exports[`switch (2) - case with block 1`] = `
 "<script lang="ts">
   switch (action)
   {
-    case "say_hello": {
+    case "say_hello":
+    {
     }
-    case "say_hi": {
+    case "say_hi":
+    {
     }
-    default: {
+    default:
+    {
     }
   }
 </script>

--- a/tests/v3-test/angular/switch/__snapshots__/allman.test.ts.snap
+++ b/tests/v3-test/angular/switch/__snapshots__/allman.test.ts.snap
@@ -22,17 +22,20 @@ exports[`switch (2) - case with block 1`] = `
 "<script lang="ts">
   switch (action)
   {
-    case "say_hello": {
+    case "say_hello":
+    {
       const message = "hello";
       console.log(message);
       break;
     }
-    case "say_hi": {
+    case "say_hi":
+    {
       const message = "hi";
       console.log(message);
       break;
     }
-    default: {
+    default:
+    {
       console.log("Empty action received.");
     }
   }

--- a/tests/v3-test/astro/issue-25/allman.test.ts
+++ b/tests/v3-test/astro/issue-25/allman.test.ts
@@ -296,11 +296,14 @@ switch (action) {
     output: `---
 switch (action)
 {
-  case "say_hello": {
+  case "say_hello":
+  {
   }
-  case "say_hi": {
+  case "say_hi":
+  {
   }
-  default: {
+  default:
+  {
   }
 }
 ---
@@ -308,11 +311,14 @@ switch (action)
 <script>
   switch (action)
   {
-    case "say_hello": {
+    case "say_hello":
+    {
     }
-    case "say_hi": {
+    case "say_hi":
+    {
     }
-    default: {
+    default:
+    {
     }
   }
 </script>

--- a/tests/v3-test/astro/switch/allman.test.ts
+++ b/tests/v3-test/astro/switch/allman.test.ts
@@ -118,17 +118,20 @@ switch (action) {
     output: `---
 switch (action)
 {
-  case "say_hello": {
+  case "say_hello":
+  {
     const message = "hello";
     console.log(message);
     break;
   }
-  case "say_hi": {
+  case "say_hi":
+  {
     const message = "hi";
     console.log(message);
     break;
   }
-  default: {
+  default:
+  {
     console.log("Empty action received.");
   }
 }
@@ -137,17 +140,20 @@ switch (action)
 <script>
   switch (action)
   {
-    case "say_hello": {
+    case "say_hello":
+    {
       const message = "hello";
       console.log(message);
       break;
     }
-    case "say_hi": {
+    case "say_hi":
+    {
       const message = "hi";
       console.log(message);
       break;
     }
-    default: {
+    default:
+    {
       console.log("Empty action received.");
     }
   }

--- a/tests/v3-test/babel/issue-25/allman.test.ts
+++ b/tests/v3-test/babel/issue-25/allman.test.ts
@@ -152,11 +152,14 @@ switch (action) {
 `,
     output: `switch (action)
 {
-  case "say_hello": {
+  case "say_hello":
+  {
   }
-  case "say_hi": {
+  case "say_hi":
+  {
   }
-  default: {
+  default:
+  {
   }
 }
 `,

--- a/tests/v3-test/babel/switch/allman.test.ts
+++ b/tests/v3-test/babel/switch/allman.test.ts
@@ -65,17 +65,20 @@ switch (action) {
 `,
     output: `switch (action)
 {
-  case "say_hello": {
+  case "say_hello":
+  {
     const message = "hello";
     console.log(message);
     break;
   }
-  case "say_hi": {
+  case "say_hi":
+  {
     const message = "hi";
     console.log(message);
     break;
   }
-  default: {
+  default:
+  {
     console.log("Empty action received.");
   }
 }

--- a/tests/v3-test/html/issue-25/__snapshots__/allman.test.ts.snap
+++ b/tests/v3-test/html/issue-25/__snapshots__/allman.test.ts.snap
@@ -103,11 +103,14 @@ exports[`switch (2) - case with block 1`] = `
 "<script lang="ts">
   switch (action)
   {
-    case "say_hello": {
+    case "say_hello":
+    {
     }
-    case "say_hi": {
+    case "say_hi":
+    {
     }
-    default: {
+    default:
+    {
     }
   }
 </script>

--- a/tests/v3-test/html/switch/__snapshots__/allman.test.ts.snap
+++ b/tests/v3-test/html/switch/__snapshots__/allman.test.ts.snap
@@ -22,17 +22,20 @@ exports[`switch (2) - case with block 1`] = `
 "<script lang="ts">
   switch (action)
   {
-    case "say_hello": {
+    case "say_hello":
+    {
       const message = "hello";
       console.log(message);
       break;
     }
-    case "say_hi": {
+    case "say_hi":
+    {
       const message = "hi";
       console.log(message);
       break;
     }
-    default: {
+    default:
+    {
       console.log("Empty action received.");
     }
   }

--- a/tests/v3-test/svelte/issue-25/__snapshots__/allman.test.ts.snap
+++ b/tests/v3-test/svelte/issue-25/__snapshots__/allman.test.ts.snap
@@ -247,11 +247,14 @@ exports[`switch (2) - case with block 1`] = `
 "<script lang="ts">
   switch (action)
   {
-    case "say_hello": {
+    case "say_hello":
+    {
     }
-    case "say_hi": {
+    case "say_hi":
+    {
     }
-    default: {
+    default:
+    {
     }
   }
 </script>
@@ -263,11 +266,14 @@ exports[`switch (2) - case with block 1`] = `
     {
       switch (action)
       {
-        case "say_hello": {
+        case "say_hello":
+        {
         }
-        case "say_hi": {
+        case "say_hi":
+        {
         }
-        default: {
+        default:
+        {
         }
       }
     }}

--- a/tests/v3-test/svelte/switch/__snapshots__/allman.test.ts.snap
+++ b/tests/v3-test/svelte/switch/__snapshots__/allman.test.ts.snap
@@ -45,17 +45,20 @@ exports[`switch (2) - case with block 1`] = `
 "<script lang="ts">
   switch (action)
   {
-    case "say_hello": {
+    case "say_hello":
+    {
       const message = "hello";
       console.log(message);
       break;
     }
-    case "say_hi": {
+    case "say_hi":
+    {
       const message = "hi";
       console.log(message);
       break;
     }
-    default: {
+    default:
+    {
       console.log("Empty action received.");
     }
   }
@@ -68,17 +71,20 @@ exports[`switch (2) - case with block 1`] = `
     {
       switch (action)
       {
-        case "say_hello": {
+        case "say_hello":
+        {
           const message = "hello";
           console.log(message);
           break;
         }
-        case "say_hi": {
+        case "say_hi":
+        {
           const message = "hi";
           console.log(message);
           break;
         }
-        default: {
+        default:
+        {
           console.log("Empty action received.");
         }
       }

--- a/tests/v3-test/typescript/issue-25/allman.test.ts
+++ b/tests/v3-test/typescript/issue-25/allman.test.ts
@@ -187,11 +187,14 @@ switch (action) {
 `,
     output: `switch (action)
 {
-  case "say_hello": {
+  case "say_hello":
+  {
   }
-  case "say_hi": {
+  case "say_hi":
+  {
   }
-  default: {
+  default:
+  {
   }
 }
 `,

--- a/tests/v3-test/typescript/switch/allman.test.ts
+++ b/tests/v3-test/typescript/switch/allman.test.ts
@@ -64,17 +64,20 @@ switch (action) {
 `,
     output: `switch (action)
 {
-  case "say_hello": {
+  case "say_hello":
+  {
     const message = "hello";
     console.log(message);
     break;
   }
-  case "say_hi": {
+  case "say_hi":
+  {
     const message = "hi";
     console.log(message);
     break;
   }
-  default: {
+  default:
+  {
     console.log("Empty action received.");
   }
 }

--- a/tests/v3-test/vue/issue-25/allman.test.ts
+++ b/tests/v3-test/vue/issue-25/allman.test.ts
@@ -439,11 +439,14 @@ switch (action) {
     output: `<script setup lang="ts">
 switch (action)
 {
-  case "say_hello": {
+  case "say_hello":
+  {
   }
-  case "say_hi": {
+  case "say_hi":
+  {
   }
-  default: {
+  default:
+  {
   }
 }
 </script>
@@ -456,11 +459,14 @@ switch (action)
       {
         switch (action)
         {
-          case 'say_hello': {
+          case 'say_hello':
+          {
           }
-          case 'say_hi': {
+          case 'say_hi':
+          {
           }
-          default: {
+          default:
+          {
           }
         }
       }

--- a/tests/v3-test/vue/switch/allman.test.ts
+++ b/tests/v3-test/vue/switch/allman.test.ts
@@ -142,17 +142,20 @@ switch (action) {
     output: `<script setup lang="ts">
 switch (action)
 {
-  case "say_hello": {
+  case "say_hello":
+  {
     const message = "hello";
     console.log(message);
     break;
   }
-  case "say_hi": {
+  case "say_hi":
+  {
     const message = "hi";
     console.log(message);
     break;
   }
-  default: {
+  default:
+  {
     console.log("Empty action received.");
   }
 }
@@ -166,17 +169,20 @@ switch (action)
       {
         switch (action)
         {
-          case 'say_hello': {
+          case 'say_hello':
+          {
             const message = 'hello';
             console.log(message);
             break;
           }
-          case 'say_hi': {
+          case 'say_hi':
+          {
             const message = 'hi';
             console.log(message);
             break;
           }
-          default: {
+          default:
+          {
             console.log('Empty action received.');
           }
         }


### PR DESCRIPTION
Refs: https://github.com/ony3000/prettier-plugin-brace-style/issues/37#issuecomment-2211007586