### PR TITLE
Fixes an error that occurs when non-script syntax is written in a script tag in HTML

### DIFF
--- a/tests/v2-test/html/script-tag/1tbs.test.ts
+++ b/tests/v2-test/html/script-tag/1tbs.test.ts
@@ -1,0 +1,26 @@
+import { format } from 'prettier';
+import { baseOptions } from 'test-settings';
+import { expect, test } from 'vitest';
+
+// eslint-disable-next-line import/no-extraneous-dependencies
+import * as thisPlugin from '@/packages/v2-plugin';
+
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: [thisPlugin],
+  parser: 'html',
+  braceStyle: '1tbs',
+};
+
+for (const fixture of fixtures) {
+  test(fixture.name, () => {
+    expect(
+      format(fixture.input, {
+        ...options,
+        ...(fixture.options ?? {}),
+      }),
+    ).toMatchSnapshot();
+  });
+}

--- a/tests/v2-test/html/script-tag/__snapshots__/1tbs.test.ts.snap
+++ b/tests/v2-test/html/script-tag/__snapshots__/1tbs.test.ts.snap
@@ -1,0 +1,48 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`(1) If a script tag has no type, it is assumed to contain JavaScript code. 1`] = `
+"<script>
+  export function Foo({ children }) {
+    return <div className="lorem ipsum dolor sit amet">{children}</div>;
+  }
+</script>
+"
+`;
+
+exports[`(2) If a script tag has an empty type, it is assumed to contain JavaScript code. 1`] = `
+"<script type="">
+  export function Foo({ children }) {
+    return <div className="lorem ipsum dolor sit amet">{children}</div>;
+  }
+</script>
+"
+`;
+
+exports[`(3) If a script tag has a type of \`text/javascript\`, it is assumed to contain JavaScript code. 1`] = `
+"<script type="text/javascript">
+  export function Foo({ children }) {
+    return <div className="lorem ipsum dolor sit amet">{children}</div>;
+  }
+</script>
+"
+`;
+
+exports[`(4) If a script tag has a \`lang\` attribute whose value is \`ts\`, it is assumed to contain TypeScript code, regardless of type. 1`] = `
+"<script lang="ts" type="anything">
+  interface MyInterface {
+    foo(): string;
+    bar: Array<number>;
+  }
+</script>
+"
+`;
+
+exports[`(5) Otherwise, leave Prettier's output as is. 1`] = `
+"<script type="application/json">
+  {
+    "lorem": "ipsum",
+    "dolor": "sit amet"
+  }
+</script>
+"
+`;

--- a/tests/v2-test/html/script-tag/__snapshots__/allman.test.ts.snap
+++ b/tests/v2-test/html/script-tag/__snapshots__/allman.test.ts.snap
@@ -1,0 +1,52 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`(1) If a script tag has no type, it is assumed to contain JavaScript code. 1`] = `
+"<script>
+  export function Foo({ children })
+  {
+    return <div className="lorem ipsum dolor sit amet">{children}</div>;
+  }
+</script>
+"
+`;
+
+exports[`(2) If a script tag has an empty type, it is assumed to contain JavaScript code. 1`] = `
+"<script type="">
+  export function Foo({ children })
+  {
+    return <div className="lorem ipsum dolor sit amet">{children}</div>;
+  }
+</script>
+"
+`;
+
+exports[`(3) If a script tag has a type of \`text/javascript\`, it is assumed to contain JavaScript code. 1`] = `
+"<script type="text/javascript">
+  export function Foo({ children })
+  {
+    return <div className="lorem ipsum dolor sit amet">{children}</div>;
+  }
+</script>
+"
+`;
+
+exports[`(4) If a script tag has a \`lang\` attribute whose value is \`ts\`, it is assumed to contain TypeScript code, regardless of type. 1`] = `
+"<script lang="ts" type="anything">
+  interface MyInterface
+  {
+    foo(): string;
+    bar: Array<number>;
+  }
+</script>
+"
+`;
+
+exports[`(5) Otherwise, leave Prettier's output as is. 1`] = `
+"<script type="application/json">
+  {
+    "lorem": "ipsum",
+    "dolor": "sit amet"
+  }
+</script>
+"
+`;

--- a/tests/v2-test/html/script-tag/__snapshots__/stroustrup.test.ts.snap
+++ b/tests/v2-test/html/script-tag/__snapshots__/stroustrup.test.ts.snap
@@ -1,0 +1,48 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`(1) If a script tag has no type, it is assumed to contain JavaScript code. 1`] = `
+"<script>
+  export function Foo({ children }) {
+    return <div className="lorem ipsum dolor sit amet">{children}</div>;
+  }
+</script>
+"
+`;
+
+exports[`(2) If a script tag has an empty type, it is assumed to contain JavaScript code. 1`] = `
+"<script type="">
+  export function Foo({ children }) {
+    return <div className="lorem ipsum dolor sit amet">{children}</div>;
+  }
+</script>
+"
+`;
+
+exports[`(3) If a script tag has a type of \`text/javascript\`, it is assumed to contain JavaScript code. 1`] = `
+"<script type="text/javascript">
+  export function Foo({ children }) {
+    return <div className="lorem ipsum dolor sit amet">{children}</div>;
+  }
+</script>
+"
+`;
+
+exports[`(4) If a script tag has a \`lang\` attribute whose value is \`ts\`, it is assumed to contain TypeScript code, regardless of type. 1`] = `
+"<script lang="ts" type="anything">
+  interface MyInterface {
+    foo(): string;
+    bar: Array<number>;
+  }
+</script>
+"
+`;
+
+exports[`(5) Otherwise, leave Prettier's output as is. 1`] = `
+"<script type="application/json">
+  {
+    "lorem": "ipsum",
+    "dolor": "sit amet"
+  }
+</script>
+"
+`;

--- a/tests/v2-test/html/script-tag/allman.test.ts
+++ b/tests/v2-test/html/script-tag/allman.test.ts
@@ -1,0 +1,26 @@
+import { format } from 'prettier';
+import { baseOptions } from 'test-settings';
+import { expect, test } from 'vitest';
+
+// eslint-disable-next-line import/no-extraneous-dependencies
+import * as thisPlugin from '@/packages/v2-plugin';
+
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: [thisPlugin],
+  parser: 'html',
+  braceStyle: 'allman',
+};
+
+for (const fixture of fixtures) {
+  test(fixture.name, () => {
+    expect(
+      format(fixture.input, {
+        ...options,
+        ...(fixture.options ?? {}),
+      }),
+    ).toMatchSnapshot();
+  });
+}

--- a/tests/v2-test/html/script-tag/fixtures.ts
+++ b/tests/v2-test/html/script-tag/fixtures.ts
@@ -1,0 +1,70 @@
+import type { Fixture } from 'test-settings';
+
+export const fixtures: Omit<Fixture, 'output'>[] = [
+  {
+    name: '(1) If a script tag has no type, it is assumed to contain JavaScript code.',
+    input: `
+<script>
+export function Foo({ children }) {
+  return (
+    <div className="lorem ipsum dolor sit amet">
+      {children}
+    </div>
+  );
+}
+</script>
+`,
+    options: {},
+  },
+  {
+    name: '(2) If a script tag has an empty type, it is assumed to contain JavaScript code.',
+    input: `
+<script type="">
+export function Foo({ children }) {
+  return (
+    <div className="lorem ipsum dolor sit amet">
+      {children}
+    </div>
+  );
+}
+</script>
+`,
+    options: {},
+  },
+  {
+    name: '(3) If a script tag has a type of `text/javascript`, it is assumed to contain JavaScript code.',
+    input: `
+<script type="text/javascript">
+export function Foo({ children }) {
+  return (
+    <div className="lorem ipsum dolor sit amet">
+      {children}
+    </div>
+  );
+}
+</script>
+`,
+    options: {},
+  },
+  {
+    name: '(4) If a script tag has a `lang` attribute whose value is `ts`, it is assumed to contain TypeScript code, regardless of type.',
+    input: `
+<script lang="ts" type="anything">
+interface MyInterface { foo(): string, bar: Array<number> }
+</script>
+`,
+    options: {},
+  },
+  {
+    name: "(5) Otherwise, leave Prettier's output as is.",
+    input: `
+<script type="application/json">
+{
+lorem: "ipsum",
+'dolor': 'sit amet',
+}
+</script>
+`,
+    options: {},
+  },
+];

--- a/tests/v2-test/html/script-tag/stroustrup.test.ts
+++ b/tests/v2-test/html/script-tag/stroustrup.test.ts
@@ -1,0 +1,26 @@
+import { format } from 'prettier';
+import { baseOptions } from 'test-settings';
+import { expect, test } from 'vitest';
+
+// eslint-disable-next-line import/no-extraneous-dependencies
+import * as thisPlugin from '@/packages/v2-plugin';
+
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: [thisPlugin],
+  parser: 'html',
+  braceStyle: 'stroustrup',
+};
+
+for (const fixture of fixtures) {
+  test(fixture.name, () => {
+    expect(
+      format(fixture.input, {
+        ...options,
+        ...(fixture.options ?? {}),
+      }),
+    ).toMatchSnapshot();
+  });
+}

--- a/tests/v3-test/html/script-tag/1tbs.test.ts
+++ b/tests/v3-test/html/script-tag/1tbs.test.ts
@@ -1,0 +1,26 @@
+import { format } from 'prettier';
+import { baseOptions } from 'test-settings';
+import { expect, test } from 'vitest';
+
+// eslint-disable-next-line import/no-extraneous-dependencies
+import * as thisPlugin from '@/packages/v3-plugin';
+
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: [thisPlugin],
+  parser: 'html',
+  braceStyle: '1tbs',
+};
+
+for (const fixture of fixtures) {
+  test(fixture.name, async () => {
+    expect(
+      await format(fixture.input, {
+        ...options,
+        ...(fixture.options ?? {}),
+      }),
+    ).toMatchSnapshot();
+  });
+}

--- a/tests/v3-test/html/script-tag/__snapshots__/1tbs.test.ts.snap
+++ b/tests/v3-test/html/script-tag/__snapshots__/1tbs.test.ts.snap
@@ -1,0 +1,48 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`(1) If a script tag has no type, it is assumed to contain JavaScript code. 1`] = `
+"<script>
+  export function Foo({ children }) {
+    return <div className="lorem ipsum dolor sit amet">{children}</div>;
+  }
+</script>
+"
+`;
+
+exports[`(2) If a script tag has an empty type, it is assumed to contain JavaScript code. 1`] = `
+"<script type="">
+  export function Foo({ children }) {
+    return <div className="lorem ipsum dolor sit amet">{children}</div>;
+  }
+</script>
+"
+`;
+
+exports[`(3) If a script tag has a type of \`text/javascript\`, it is assumed to contain JavaScript code. 1`] = `
+"<script type="text/javascript">
+  export function Foo({ children }) {
+    return <div className="lorem ipsum dolor sit amet">{children}</div>;
+  }
+</script>
+"
+`;
+
+exports[`(4) If a script tag has a \`lang\` attribute whose value is \`ts\`, it is assumed to contain TypeScript code, regardless of type. 1`] = `
+"<script lang="ts" type="anything">
+  interface MyInterface {
+    foo(): string;
+    bar: Array<number>;
+  }
+</script>
+"
+`;
+
+exports[`(5) Otherwise, leave Prettier's output as is. 1`] = `
+"<script type="application/json">
+  {
+    "lorem": "ipsum",
+    "dolor": "sit amet"
+  }
+</script>
+"
+`;

--- a/tests/v3-test/html/script-tag/__snapshots__/allman.test.ts.snap
+++ b/tests/v3-test/html/script-tag/__snapshots__/allman.test.ts.snap
@@ -1,0 +1,52 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`(1) If a script tag has no type, it is assumed to contain JavaScript code. 1`] = `
+"<script>
+  export function Foo({ children })
+  {
+    return <div className="lorem ipsum dolor sit amet">{children}</div>;
+  }
+</script>
+"
+`;
+
+exports[`(2) If a script tag has an empty type, it is assumed to contain JavaScript code. 1`] = `
+"<script type="">
+  export function Foo({ children })
+  {
+    return <div className="lorem ipsum dolor sit amet">{children}</div>;
+  }
+</script>
+"
+`;
+
+exports[`(3) If a script tag has a type of \`text/javascript\`, it is assumed to contain JavaScript code. 1`] = `
+"<script type="text/javascript">
+  export function Foo({ children })
+  {
+    return <div className="lorem ipsum dolor sit amet">{children}</div>;
+  }
+</script>
+"
+`;
+
+exports[`(4) If a script tag has a \`lang\` attribute whose value is \`ts\`, it is assumed to contain TypeScript code, regardless of type. 1`] = `
+"<script lang="ts" type="anything">
+  interface MyInterface
+  {
+    foo(): string;
+    bar: Array<number>;
+  }
+</script>
+"
+`;
+
+exports[`(5) Otherwise, leave Prettier's output as is. 1`] = `
+"<script type="application/json">
+  {
+    "lorem": "ipsum",
+    "dolor": "sit amet"
+  }
+</script>
+"
+`;

--- a/tests/v3-test/html/script-tag/__snapshots__/stroustrup.test.ts.snap
+++ b/tests/v3-test/html/script-tag/__snapshots__/stroustrup.test.ts.snap
@@ -1,0 +1,48 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`(1) If a script tag has no type, it is assumed to contain JavaScript code. 1`] = `
+"<script>
+  export function Foo({ children }) {
+    return <div className="lorem ipsum dolor sit amet">{children}</div>;
+  }
+</script>
+"
+`;
+
+exports[`(2) If a script tag has an empty type, it is assumed to contain JavaScript code. 1`] = `
+"<script type="">
+  export function Foo({ children }) {
+    return <div className="lorem ipsum dolor sit amet">{children}</div>;
+  }
+</script>
+"
+`;
+
+exports[`(3) If a script tag has a type of \`text/javascript\`, it is assumed to contain JavaScript code. 1`] = `
+"<script type="text/javascript">
+  export function Foo({ children }) {
+    return <div className="lorem ipsum dolor sit amet">{children}</div>;
+  }
+</script>
+"
+`;
+
+exports[`(4) If a script tag has a \`lang\` attribute whose value is \`ts\`, it is assumed to contain TypeScript code, regardless of type. 1`] = `
+"<script lang="ts" type="anything">
+  interface MyInterface {
+    foo(): string;
+    bar: Array<number>;
+  }
+</script>
+"
+`;
+
+exports[`(5) Otherwise, leave Prettier's output as is. 1`] = `
+"<script type="application/json">
+  {
+    "lorem": "ipsum",
+    "dolor": "sit amet"
+  }
+</script>
+"
+`;

--- a/tests/v3-test/html/script-tag/allman.test.ts
+++ b/tests/v3-test/html/script-tag/allman.test.ts
@@ -1,0 +1,26 @@
+import { format } from 'prettier';
+import { baseOptions } from 'test-settings';
+import { expect, test } from 'vitest';
+
+// eslint-disable-next-line import/no-extraneous-dependencies
+import * as thisPlugin from '@/packages/v3-plugin';
+
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: [thisPlugin],
+  parser: 'html',
+  braceStyle: 'allman',
+};
+
+for (const fixture of fixtures) {
+  test(fixture.name, async () => {
+    expect(
+      await format(fixture.input, {
+        ...options,
+        ...(fixture.options ?? {}),
+      }),
+    ).toMatchSnapshot();
+  });
+}

--- a/tests/v3-test/html/script-tag/fixtures.ts
+++ b/tests/v3-test/html/script-tag/fixtures.ts
@@ -1,0 +1,70 @@
+import type { Fixture } from 'test-settings';
+
+export const fixtures: Omit<Fixture, 'output'>[] = [
+  {
+    name: '(1) If a script tag has no type, it is assumed to contain JavaScript code.',
+    input: `
+<script>
+export function Foo({ children }) {
+  return (
+    <div className="lorem ipsum dolor sit amet">
+      {children}
+    </div>
+  );
+}
+</script>
+`,
+    options: {},
+  },
+  {
+    name: '(2) If a script tag has an empty type, it is assumed to contain JavaScript code.',
+    input: `
+<script type="">
+export function Foo({ children }) {
+  return (
+    <div className="lorem ipsum dolor sit amet">
+      {children}
+    </div>
+  );
+}
+</script>
+`,
+    options: {},
+  },
+  {
+    name: '(3) If a script tag has a type of `text/javascript`, it is assumed to contain JavaScript code.',
+    input: `
+<script type="text/javascript">
+export function Foo({ children }) {
+  return (
+    <div className="lorem ipsum dolor sit amet">
+      {children}
+    </div>
+  );
+}
+</script>
+`,
+    options: {},
+  },
+  {
+    name: '(4) If a script tag has a `lang` attribute whose value is `ts`, it is assumed to contain TypeScript code, regardless of type.',
+    input: `
+<script lang="ts" type="anything">
+interface MyInterface { foo(): string, bar: Array<number> }
+</script>
+`,
+    options: {},
+  },
+  {
+    name: "(5) Otherwise, leave Prettier's output as is.",
+    input: `
+<script type="application/json">
+{
+lorem: "ipsum",
+'dolor': 'sit amet',
+}
+</script>
+`,
+    options: {},
+  },
+];

--- a/tests/v3-test/html/script-tag/stroustrup.test.ts
+++ b/tests/v3-test/html/script-tag/stroustrup.test.ts
@@ -1,0 +1,26 @@
+import { format } from 'prettier';
+import { baseOptions } from 'test-settings';
+import { expect, test } from 'vitest';
+
+// eslint-disable-next-line import/no-extraneous-dependencies
+import * as thisPlugin from '@/packages/v3-plugin';
+
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: [thisPlugin],
+  parser: 'html',
+  braceStyle: 'stroustrup',
+};
+
+for (const fixture of fixtures) {
+  test(fixture.name, async () => {
+    expect(
+      await format(fixture.input, {
+        ...options,
+        ...(fixture.options ?? {}),
+      }),
+    ).toMatchSnapshot();
+  });
+}


### PR DESCRIPTION
Refs: [prettier-plugin-classnames#81](https://github.com/ony3000/prettier-plugin-classnames/pull/81)