### PR TITLE
Leave Prettier's output as is for code blocks embedded in markdown and mdx

### DIFF
--- a/src/packages/v2-plugin/parsers.ts
+++ b/src/packages/v2-plugin/parsers.ts
@@ -5,6 +5,8 @@ import { parsers as babelParsers } from 'prettier/parser-babel';
 import { parsers as htmlParsers } from 'prettier/parser-html';
 import { parsers as typescriptParsers } from 'prettier/parser-typescript';
 
+const EOL = '\n';
+
 const addon = {
   parseBabel: (text: string, options: ParserOptions) =>
     babelParsers.babel.parse(text, { babel: babelParsers.babel }, options),
@@ -25,6 +27,34 @@ function transformParser(
       parsers: { [parserName: string]: Parser },
       options: ParserOptions & ThisPluginOptions,
     ): FormattedTextAST => {
+      if (options.parentParser === 'markdown' || options.parentParser === 'mdx') {
+        let codeblockStart = '```';
+        const codeblockEnd = '```';
+
+        if (options.parser === 'babel') {
+          codeblockStart = '```jsx';
+        } else if (options.parser === 'typescript') {
+          codeblockStart = '```tsx';
+        }
+
+        const formattedCodeblock = format(`${codeblockStart}${EOL}${text}${EOL}${codeblockEnd}`, {
+          ...options,
+          plugins: [],
+          rangeEnd: Infinity,
+          endOfLine: 'lf',
+          parser: options.parentParser,
+          parentParser: undefined,
+        });
+        const formattedText = formattedCodeblock
+          .trim()
+          .slice(`${codeblockStart}${EOL}`.length, -`${EOL}${codeblockEnd}`.length);
+
+        return {
+          type: 'FormattedText',
+          body: formattedText,
+        };
+      }
+
       const plugins = options.plugins.filter((plugin) => typeof plugin !== 'string') as Plugin[];
 
       let languageImplementedPlugin: Plugin | undefined;

--- a/tests/v2-test/markdown/code-block/1tbs.test.ts
+++ b/tests/v2-test/markdown/code-block/1tbs.test.ts
@@ -1,0 +1,26 @@
+import { format } from 'prettier';
+import { baseOptions } from 'test-settings';
+import { expect, test } from 'vitest';
+
+// eslint-disable-next-line import/no-extraneous-dependencies
+import * as thisPlugin from '@/packages/v2-plugin';
+
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: [thisPlugin],
+  parser: 'markdown',
+  braceStyle: '1tbs',
+};
+
+for (const fixture of fixtures) {
+  test(fixture.name, () => {
+    expect(
+      format(fixture.input, {
+        ...options,
+        ...(fixture.options ?? {}),
+      }),
+    ).toMatchSnapshot();
+  });
+}

--- a/tests/v2-test/markdown/code-block/__snapshots__/1tbs.test.ts.snap
+++ b/tests/v2-test/markdown/code-block/__snapshots__/1tbs.test.ts.snap
@@ -1,0 +1,55 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`(1) This plugin doesn't support markdown parser, so it leaves Prettier's output as is. 1`] = `
+"\`\`\`jsx
+<div />
+\`\`\`
+"
+`;
+
+exports[`(2) This plugin doesn't support markdown parser, so it leaves Prettier's output as is. 1`] = `
+"\`\`\`jsx
+import foo from "foo";
+
+<div />;
+\`\`\`
+"
+`;
+
+exports[`(3) This plugin doesn't support markdown parser, so it leaves Prettier's output as is. 1`] = `
+"\`\`\`jsx
+if (foo) {
+  bar();
+} else {
+  baz();
+}
+\`\`\`
+"
+`;
+
+exports[`(4) This plugin doesn't support markdown parser, so it leaves Prettier's output as is. 1`] = `
+"\`\`\`tsx
+<div />
+\`\`\`
+"
+`;
+
+exports[`(5) This plugin doesn't support markdown parser, so it leaves Prettier's output as is. 1`] = `
+"\`\`\`tsx
+import foo from "foo";
+
+<div />;
+\`\`\`
+"
+`;
+
+exports[`(6) This plugin doesn't support markdown parser, so it leaves Prettier's output as is. 1`] = `
+"\`\`\`tsx
+if (foo) {
+  bar();
+} else {
+  baz();
+}
+\`\`\`
+"
+`;

--- a/tests/v2-test/markdown/code-block/__snapshots__/allman.test.ts.snap
+++ b/tests/v2-test/markdown/code-block/__snapshots__/allman.test.ts.snap
@@ -1,0 +1,55 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`(1) This plugin doesn't support markdown parser, so it leaves Prettier's output as is. 1`] = `
+"\`\`\`jsx
+<div />
+\`\`\`
+"
+`;
+
+exports[`(2) This plugin doesn't support markdown parser, so it leaves Prettier's output as is. 1`] = `
+"\`\`\`jsx
+import foo from "foo";
+
+<div />;
+\`\`\`
+"
+`;
+
+exports[`(3) This plugin doesn't support markdown parser, so it leaves Prettier's output as is. 1`] = `
+"\`\`\`jsx
+if (foo) {
+  bar();
+} else {
+  baz();
+}
+\`\`\`
+"
+`;
+
+exports[`(4) This plugin doesn't support markdown parser, so it leaves Prettier's output as is. 1`] = `
+"\`\`\`tsx
+<div />
+\`\`\`
+"
+`;
+
+exports[`(5) This plugin doesn't support markdown parser, so it leaves Prettier's output as is. 1`] = `
+"\`\`\`tsx
+import foo from "foo";
+
+<div />;
+\`\`\`
+"
+`;
+
+exports[`(6) This plugin doesn't support markdown parser, so it leaves Prettier's output as is. 1`] = `
+"\`\`\`tsx
+if (foo) {
+  bar();
+} else {
+  baz();
+}
+\`\`\`
+"
+`;

--- a/tests/v2-test/markdown/code-block/__snapshots__/stroustrup.test.ts.snap
+++ b/tests/v2-test/markdown/code-block/__snapshots__/stroustrup.test.ts.snap
@@ -1,0 +1,55 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`(1) This plugin doesn't support markdown parser, so it leaves Prettier's output as is. 1`] = `
+"\`\`\`jsx
+<div />
+\`\`\`
+"
+`;
+
+exports[`(2) This plugin doesn't support markdown parser, so it leaves Prettier's output as is. 1`] = `
+"\`\`\`jsx
+import foo from "foo";
+
+<div />;
+\`\`\`
+"
+`;
+
+exports[`(3) This plugin doesn't support markdown parser, so it leaves Prettier's output as is. 1`] = `
+"\`\`\`jsx
+if (foo) {
+  bar();
+} else {
+  baz();
+}
+\`\`\`
+"
+`;
+
+exports[`(4) This plugin doesn't support markdown parser, so it leaves Prettier's output as is. 1`] = `
+"\`\`\`tsx
+<div />
+\`\`\`
+"
+`;
+
+exports[`(5) This plugin doesn't support markdown parser, so it leaves Prettier's output as is. 1`] = `
+"\`\`\`tsx
+import foo from "foo";
+
+<div />;
+\`\`\`
+"
+`;
+
+exports[`(6) This plugin doesn't support markdown parser, so it leaves Prettier's output as is. 1`] = `
+"\`\`\`tsx
+if (foo) {
+  bar();
+} else {
+  baz();
+}
+\`\`\`
+"
+`;

--- a/tests/v2-test/markdown/code-block/allman.test.ts
+++ b/tests/v2-test/markdown/code-block/allman.test.ts
@@ -1,0 +1,26 @@
+import { format } from 'prettier';
+import { baseOptions } from 'test-settings';
+import { expect, test } from 'vitest';
+
+// eslint-disable-next-line import/no-extraneous-dependencies
+import * as thisPlugin from '@/packages/v2-plugin';
+
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: [thisPlugin],
+  parser: 'markdown',
+  braceStyle: 'allman',
+};
+
+for (const fixture of fixtures) {
+  test(fixture.name, () => {
+    expect(
+      format(fixture.input, {
+        ...options,
+        ...(fixture.options ?? {}),
+      }),
+    ).toMatchSnapshot();
+  });
+}

--- a/tests/v2-test/markdown/code-block/fixtures.ts
+++ b/tests/v2-test/markdown/code-block/fixtures.ts
@@ -1,0 +1,62 @@
+import type { Fixture } from 'test-settings';
+
+export const fixtures: Omit<Fixture, 'output'>[] = [
+  {
+    name: "(1) This plugin doesn't support markdown parser, so it leaves Prettier's output as is.",
+    input: `
+\`\`\`jsx
+<div />;
+\`\`\`
+`,
+    options: {},
+  },
+  {
+    name: "(2) This plugin doesn't support markdown parser, so it leaves Prettier's output as is.",
+    input: `
+\`\`\`jsx
+import foo from 'foo'
+
+<div />
+\`\`\`
+`,
+    options: {},
+  },
+  {
+    name: "(3) This plugin doesn't support markdown parser, so it leaves Prettier's output as is.",
+    input: `
+\`\`\`jsx
+if (foo) { bar(); } else { baz(); }
+\`\`\`
+`,
+    options: {},
+  },
+  {
+    name: "(4) This plugin doesn't support markdown parser, so it leaves Prettier's output as is.",
+    input: `
+\`\`\`tsx
+<div />;
+\`\`\`
+`,
+    options: {},
+  },
+  {
+    name: "(5) This plugin doesn't support markdown parser, so it leaves Prettier's output as is.",
+    input: `
+\`\`\`tsx
+import foo from 'foo'
+
+<div />
+\`\`\`
+`,
+    options: {},
+  },
+  {
+    name: "(6) This plugin doesn't support markdown parser, so it leaves Prettier's output as is.",
+    input: `
+\`\`\`tsx
+if (foo) { bar(); } else { baz(); }
+\`\`\`
+`,
+    options: {},
+  },
+];

--- a/tests/v2-test/markdown/code-block/stroustrup.test.ts
+++ b/tests/v2-test/markdown/code-block/stroustrup.test.ts
@@ -1,0 +1,26 @@
+import { format } from 'prettier';
+import { baseOptions } from 'test-settings';
+import { expect, test } from 'vitest';
+
+// eslint-disable-next-line import/no-extraneous-dependencies
+import * as thisPlugin from '@/packages/v2-plugin';
+
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: [thisPlugin],
+  parser: 'markdown',
+  braceStyle: 'stroustrup',
+};
+
+for (const fixture of fixtures) {
+  test(fixture.name, () => {
+    expect(
+      format(fixture.input, {
+        ...options,
+        ...(fixture.options ?? {}),
+      }),
+    ).toMatchSnapshot();
+  });
+}

--- a/tests/v2-test/mdx/code-block/1tbs.test.ts
+++ b/tests/v2-test/mdx/code-block/1tbs.test.ts
@@ -1,0 +1,26 @@
+import { format } from 'prettier';
+import { baseOptions } from 'test-settings';
+import { expect, test } from 'vitest';
+
+// eslint-disable-next-line import/no-extraneous-dependencies
+import * as thisPlugin from '@/packages/v2-plugin';
+
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: [thisPlugin],
+  parser: 'mdx',
+  braceStyle: '1tbs',
+};
+
+for (const fixture of fixtures) {
+  test(fixture.name, () => {
+    expect(
+      format(fixture.input, {
+        ...options,
+        ...(fixture.options ?? {}),
+      }),
+    ).toMatchSnapshot();
+  });
+}

--- a/tests/v2-test/mdx/code-block/__snapshots__/1tbs.test.ts.snap
+++ b/tests/v2-test/mdx/code-block/__snapshots__/1tbs.test.ts.snap
@@ -1,0 +1,55 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`(1) This plugin doesn't support markdown parser, so it leaves Prettier's output as is. 1`] = `
+"\`\`\`jsx
+<div />
+\`\`\`
+"
+`;
+
+exports[`(2) This plugin doesn't support markdown parser, so it leaves Prettier's output as is. 1`] = `
+"\`\`\`jsx
+import foo from "foo";
+
+<div />;
+\`\`\`
+"
+`;
+
+exports[`(3) This plugin doesn't support markdown parser, so it leaves Prettier's output as is. 1`] = `
+"\`\`\`jsx
+if (foo) {
+  bar();
+} else {
+  baz();
+}
+\`\`\`
+"
+`;
+
+exports[`(4) This plugin doesn't support markdown parser, so it leaves Prettier's output as is. 1`] = `
+"\`\`\`tsx
+<div />
+\`\`\`
+"
+`;
+
+exports[`(5) This plugin doesn't support markdown parser, so it leaves Prettier's output as is. 1`] = `
+"\`\`\`tsx
+import foo from "foo";
+
+<div />;
+\`\`\`
+"
+`;
+
+exports[`(6) This plugin doesn't support markdown parser, so it leaves Prettier's output as is. 1`] = `
+"\`\`\`tsx
+if (foo) {
+  bar();
+} else {
+  baz();
+}
+\`\`\`
+"
+`;

--- a/tests/v2-test/mdx/code-block/__snapshots__/allman.test.ts.snap
+++ b/tests/v2-test/mdx/code-block/__snapshots__/allman.test.ts.snap
@@ -1,0 +1,55 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`(1) This plugin doesn't support markdown parser, so it leaves Prettier's output as is. 1`] = `
+"\`\`\`jsx
+<div />
+\`\`\`
+"
+`;
+
+exports[`(2) This plugin doesn't support markdown parser, so it leaves Prettier's output as is. 1`] = `
+"\`\`\`jsx
+import foo from "foo";
+
+<div />;
+\`\`\`
+"
+`;
+
+exports[`(3) This plugin doesn't support markdown parser, so it leaves Prettier's output as is. 1`] = `
+"\`\`\`jsx
+if (foo) {
+  bar();
+} else {
+  baz();
+}
+\`\`\`
+"
+`;
+
+exports[`(4) This plugin doesn't support markdown parser, so it leaves Prettier's output as is. 1`] = `
+"\`\`\`tsx
+<div />
+\`\`\`
+"
+`;
+
+exports[`(5) This plugin doesn't support markdown parser, so it leaves Prettier's output as is. 1`] = `
+"\`\`\`tsx
+import foo from "foo";
+
+<div />;
+\`\`\`
+"
+`;
+
+exports[`(6) This plugin doesn't support markdown parser, so it leaves Prettier's output as is. 1`] = `
+"\`\`\`tsx
+if (foo) {
+  bar();
+} else {
+  baz();
+}
+\`\`\`
+"
+`;

--- a/tests/v2-test/mdx/code-block/__snapshots__/stroustrup.test.ts.snap
+++ b/tests/v2-test/mdx/code-block/__snapshots__/stroustrup.test.ts.snap
@@ -1,0 +1,55 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`(1) This plugin doesn't support markdown parser, so it leaves Prettier's output as is. 1`] = `
+"\`\`\`jsx
+<div />
+\`\`\`
+"
+`;
+
+exports[`(2) This plugin doesn't support markdown parser, so it leaves Prettier's output as is. 1`] = `
+"\`\`\`jsx
+import foo from "foo";
+
+<div />;
+\`\`\`
+"
+`;
+
+exports[`(3) This plugin doesn't support markdown parser, so it leaves Prettier's output as is. 1`] = `
+"\`\`\`jsx
+if (foo) {
+  bar();
+} else {
+  baz();
+}
+\`\`\`
+"
+`;
+
+exports[`(4) This plugin doesn't support markdown parser, so it leaves Prettier's output as is. 1`] = `
+"\`\`\`tsx
+<div />
+\`\`\`
+"
+`;
+
+exports[`(5) This plugin doesn't support markdown parser, so it leaves Prettier's output as is. 1`] = `
+"\`\`\`tsx
+import foo from "foo";
+
+<div />;
+\`\`\`
+"
+`;
+
+exports[`(6) This plugin doesn't support markdown parser, so it leaves Prettier's output as is. 1`] = `
+"\`\`\`tsx
+if (foo) {
+  bar();
+} else {
+  baz();
+}
+\`\`\`
+"
+`;

--- a/tests/v2-test/mdx/code-block/allman.test.ts
+++ b/tests/v2-test/mdx/code-block/allman.test.ts
@@ -1,0 +1,26 @@
+import { format } from 'prettier';
+import { baseOptions } from 'test-settings';
+import { expect, test } from 'vitest';
+
+// eslint-disable-next-line import/no-extraneous-dependencies
+import * as thisPlugin from '@/packages/v2-plugin';
+
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: [thisPlugin],
+  parser: 'mdx',
+  braceStyle: 'allman',
+};
+
+for (const fixture of fixtures) {
+  test(fixture.name, () => {
+    expect(
+      format(fixture.input, {
+        ...options,
+        ...(fixture.options ?? {}),
+      }),
+    ).toMatchSnapshot();
+  });
+}

--- a/tests/v2-test/mdx/code-block/fixtures.ts
+++ b/tests/v2-test/mdx/code-block/fixtures.ts
@@ -1,0 +1,62 @@
+import type { Fixture } from 'test-settings';
+
+export const fixtures: Omit<Fixture, 'output'>[] = [
+  {
+    name: "(1) This plugin doesn't support markdown parser, so it leaves Prettier's output as is.",
+    input: `
+\`\`\`jsx
+<div />;
+\`\`\`
+`,
+    options: {},
+  },
+  {
+    name: "(2) This plugin doesn't support markdown parser, so it leaves Prettier's output as is.",
+    input: `
+\`\`\`jsx
+import foo from 'foo'
+
+<div />
+\`\`\`
+`,
+    options: {},
+  },
+  {
+    name: "(3) This plugin doesn't support markdown parser, so it leaves Prettier's output as is.",
+    input: `
+\`\`\`jsx
+if (foo) { bar(); } else { baz(); }
+\`\`\`
+`,
+    options: {},
+  },
+  {
+    name: "(4) This plugin doesn't support markdown parser, so it leaves Prettier's output as is.",
+    input: `
+\`\`\`tsx
+<div />;
+\`\`\`
+`,
+    options: {},
+  },
+  {
+    name: "(5) This plugin doesn't support markdown parser, so it leaves Prettier's output as is.",
+    input: `
+\`\`\`tsx
+import foo from 'foo'
+
+<div />
+\`\`\`
+`,
+    options: {},
+  },
+  {
+    name: "(6) This plugin doesn't support markdown parser, so it leaves Prettier's output as is.",
+    input: `
+\`\`\`tsx
+if (foo) { bar(); } else { baz(); }
+\`\`\`
+`,
+    options: {},
+  },
+];

--- a/tests/v2-test/mdx/code-block/stroustrup.test.ts
+++ b/tests/v2-test/mdx/code-block/stroustrup.test.ts
@@ -1,0 +1,26 @@
+import { format } from 'prettier';
+import { baseOptions } from 'test-settings';
+import { expect, test } from 'vitest';
+
+// eslint-disable-next-line import/no-extraneous-dependencies
+import * as thisPlugin from '@/packages/v2-plugin';
+
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: [thisPlugin],
+  parser: 'mdx',
+  braceStyle: 'stroustrup',
+};
+
+for (const fixture of fixtures) {
+  test(fixture.name, () => {
+    expect(
+      format(fixture.input, {
+        ...options,
+        ...(fixture.options ?? {}),
+      }),
+    ).toMatchSnapshot();
+  });
+}

--- a/tests/v3-test/markdown/code-block/1tbs.test.ts
+++ b/tests/v3-test/markdown/code-block/1tbs.test.ts
@@ -1,0 +1,26 @@
+import { format } from 'prettier';
+import { baseOptions } from 'test-settings';
+import { expect, test } from 'vitest';
+
+// eslint-disable-next-line import/no-extraneous-dependencies
+import * as thisPlugin from '@/packages/v3-plugin';
+
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: [thisPlugin],
+  parser: 'markdown',
+  braceStyle: '1tbs',
+};
+
+for (const fixture of fixtures) {
+  test(fixture.name, async () => {
+    expect(
+      await format(fixture.input, {
+        ...options,
+        ...(fixture.options ?? {}),
+      }),
+    ).toMatchSnapshot();
+  });
+}

--- a/tests/v3-test/markdown/code-block/__snapshots__/1tbs.test.ts.snap
+++ b/tests/v3-test/markdown/code-block/__snapshots__/1tbs.test.ts.snap
@@ -1,0 +1,55 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`(1) This plugin doesn't support markdown parser, so it leaves Prettier's output as is. 1`] = `
+"\`\`\`jsx
+<div />
+\`\`\`
+"
+`;
+
+exports[`(2) This plugin doesn't support markdown parser, so it leaves Prettier's output as is. 1`] = `
+"\`\`\`jsx
+import foo from "foo";
+
+<div />;
+\`\`\`
+"
+`;
+
+exports[`(3) This plugin doesn't support markdown parser, so it leaves Prettier's output as is. 1`] = `
+"\`\`\`jsx
+if (foo) {
+  bar();
+} else {
+  baz();
+}
+\`\`\`
+"
+`;
+
+exports[`(4) This plugin doesn't support markdown parser, so it leaves Prettier's output as is. 1`] = `
+"\`\`\`tsx
+<div />
+\`\`\`
+"
+`;
+
+exports[`(5) This plugin doesn't support markdown parser, so it leaves Prettier's output as is. 1`] = `
+"\`\`\`tsx
+import foo from "foo";
+
+<div />;
+\`\`\`
+"
+`;
+
+exports[`(6) This plugin doesn't support markdown parser, so it leaves Prettier's output as is. 1`] = `
+"\`\`\`tsx
+if (foo) {
+  bar();
+} else {
+  baz();
+}
+\`\`\`
+"
+`;

--- a/tests/v3-test/markdown/code-block/__snapshots__/allman.test.ts.snap
+++ b/tests/v3-test/markdown/code-block/__snapshots__/allman.test.ts.snap
@@ -1,0 +1,55 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`(1) This plugin doesn't support markdown parser, so it leaves Prettier's output as is. 1`] = `
+"\`\`\`jsx
+<div />
+\`\`\`
+"
+`;
+
+exports[`(2) This plugin doesn't support markdown parser, so it leaves Prettier's output as is. 1`] = `
+"\`\`\`jsx
+import foo from "foo";
+
+<div />;
+\`\`\`
+"
+`;
+
+exports[`(3) This plugin doesn't support markdown parser, so it leaves Prettier's output as is. 1`] = `
+"\`\`\`jsx
+if (foo) {
+  bar();
+} else {
+  baz();
+}
+\`\`\`
+"
+`;
+
+exports[`(4) This plugin doesn't support markdown parser, so it leaves Prettier's output as is. 1`] = `
+"\`\`\`tsx
+<div />
+\`\`\`
+"
+`;
+
+exports[`(5) This plugin doesn't support markdown parser, so it leaves Prettier's output as is. 1`] = `
+"\`\`\`tsx
+import foo from "foo";
+
+<div />;
+\`\`\`
+"
+`;
+
+exports[`(6) This plugin doesn't support markdown parser, so it leaves Prettier's output as is. 1`] = `
+"\`\`\`tsx
+if (foo) {
+  bar();
+} else {
+  baz();
+}
+\`\`\`
+"
+`;

--- a/tests/v3-test/markdown/code-block/__snapshots__/stroustrup.test.ts.snap
+++ b/tests/v3-test/markdown/code-block/__snapshots__/stroustrup.test.ts.snap
@@ -1,0 +1,55 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`(1) This plugin doesn't support markdown parser, so it leaves Prettier's output as is. 1`] = `
+"\`\`\`jsx
+<div />
+\`\`\`
+"
+`;
+
+exports[`(2) This plugin doesn't support markdown parser, so it leaves Prettier's output as is. 1`] = `
+"\`\`\`jsx
+import foo from "foo";
+
+<div />;
+\`\`\`
+"
+`;
+
+exports[`(3) This plugin doesn't support markdown parser, so it leaves Prettier's output as is. 1`] = `
+"\`\`\`jsx
+if (foo) {
+  bar();
+} else {
+  baz();
+}
+\`\`\`
+"
+`;
+
+exports[`(4) This plugin doesn't support markdown parser, so it leaves Prettier's output as is. 1`] = `
+"\`\`\`tsx
+<div />
+\`\`\`
+"
+`;
+
+exports[`(5) This plugin doesn't support markdown parser, so it leaves Prettier's output as is. 1`] = `
+"\`\`\`tsx
+import foo from "foo";
+
+<div />;
+\`\`\`
+"
+`;
+
+exports[`(6) This plugin doesn't support markdown parser, so it leaves Prettier's output as is. 1`] = `
+"\`\`\`tsx
+if (foo) {
+  bar();
+} else {
+  baz();
+}
+\`\`\`
+"
+`;

--- a/tests/v3-test/markdown/code-block/allman.test.ts
+++ b/tests/v3-test/markdown/code-block/allman.test.ts
@@ -1,0 +1,26 @@
+import { format } from 'prettier';
+import { baseOptions } from 'test-settings';
+import { expect, test } from 'vitest';
+
+// eslint-disable-next-line import/no-extraneous-dependencies
+import * as thisPlugin from '@/packages/v3-plugin';
+
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: [thisPlugin],
+  parser: 'markdown',
+  braceStyle: 'allman',
+};
+
+for (const fixture of fixtures) {
+  test(fixture.name, async () => {
+    expect(
+      await format(fixture.input, {
+        ...options,
+        ...(fixture.options ?? {}),
+      }),
+    ).toMatchSnapshot();
+  });
+}

--- a/tests/v3-test/markdown/code-block/fixtures.ts
+++ b/tests/v3-test/markdown/code-block/fixtures.ts
@@ -1,0 +1,62 @@
+import type { Fixture } from 'test-settings';
+
+export const fixtures: Omit<Fixture, 'output'>[] = [
+  {
+    name: "(1) This plugin doesn't support markdown parser, so it leaves Prettier's output as is.",
+    input: `
+\`\`\`jsx
+<div />;
+\`\`\`
+`,
+    options: {},
+  },
+  {
+    name: "(2) This plugin doesn't support markdown parser, so it leaves Prettier's output as is.",
+    input: `
+\`\`\`jsx
+import foo from 'foo'
+
+<div />
+\`\`\`
+`,
+    options: {},
+  },
+  {
+    name: "(3) This plugin doesn't support markdown parser, so it leaves Prettier's output as is.",
+    input: `
+\`\`\`jsx
+if (foo) { bar(); } else { baz(); }
+\`\`\`
+`,
+    options: {},
+  },
+  {
+    name: "(4) This plugin doesn't support markdown parser, so it leaves Prettier's output as is.",
+    input: `
+\`\`\`tsx
+<div />;
+\`\`\`
+`,
+    options: {},
+  },
+  {
+    name: "(5) This plugin doesn't support markdown parser, so it leaves Prettier's output as is.",
+    input: `
+\`\`\`tsx
+import foo from 'foo'
+
+<div />
+\`\`\`
+`,
+    options: {},
+  },
+  {
+    name: "(6) This plugin doesn't support markdown parser, so it leaves Prettier's output as is.",
+    input: `
+\`\`\`tsx
+if (foo) { bar(); } else { baz(); }
+\`\`\`
+`,
+    options: {},
+  },
+];

--- a/tests/v3-test/markdown/code-block/stroustrup.test.ts
+++ b/tests/v3-test/markdown/code-block/stroustrup.test.ts
@@ -1,0 +1,26 @@
+import { format } from 'prettier';
+import { baseOptions } from 'test-settings';
+import { expect, test } from 'vitest';
+
+// eslint-disable-next-line import/no-extraneous-dependencies
+import * as thisPlugin from '@/packages/v3-plugin';
+
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: [thisPlugin],
+  parser: 'markdown',
+  braceStyle: 'stroustrup',
+};
+
+for (const fixture of fixtures) {
+  test(fixture.name, async () => {
+    expect(
+      await format(fixture.input, {
+        ...options,
+        ...(fixture.options ?? {}),
+      }),
+    ).toMatchSnapshot();
+  });
+}

--- a/tests/v3-test/mdx/code-block/1tbs.test.ts
+++ b/tests/v3-test/mdx/code-block/1tbs.test.ts
@@ -1,0 +1,26 @@
+import { format } from 'prettier';
+import { baseOptions } from 'test-settings';
+import { expect, test } from 'vitest';
+
+// eslint-disable-next-line import/no-extraneous-dependencies
+import * as thisPlugin from '@/packages/v3-plugin';
+
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: [thisPlugin],
+  parser: 'mdx',
+  braceStyle: '1tbs',
+};
+
+for (const fixture of fixtures) {
+  test(fixture.name, async () => {
+    expect(
+      await format(fixture.input, {
+        ...options,
+        ...(fixture.options ?? {}),
+      }),
+    ).toMatchSnapshot();
+  });
+}

--- a/tests/v3-test/mdx/code-block/__snapshots__/1tbs.test.ts.snap
+++ b/tests/v3-test/mdx/code-block/__snapshots__/1tbs.test.ts.snap
@@ -1,0 +1,55 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`(1) This plugin doesn't support markdown parser, so it leaves Prettier's output as is. 1`] = `
+"\`\`\`jsx
+<div />
+\`\`\`
+"
+`;
+
+exports[`(2) This plugin doesn't support markdown parser, so it leaves Prettier's output as is. 1`] = `
+"\`\`\`jsx
+import foo from "foo";
+
+<div />;
+\`\`\`
+"
+`;
+
+exports[`(3) This plugin doesn't support markdown parser, so it leaves Prettier's output as is. 1`] = `
+"\`\`\`jsx
+if (foo) {
+  bar();
+} else {
+  baz();
+}
+\`\`\`
+"
+`;
+
+exports[`(4) This plugin doesn't support markdown parser, so it leaves Prettier's output as is. 1`] = `
+"\`\`\`tsx
+<div />
+\`\`\`
+"
+`;
+
+exports[`(5) This plugin doesn't support markdown parser, so it leaves Prettier's output as is. 1`] = `
+"\`\`\`tsx
+import foo from "foo";
+
+<div />;
+\`\`\`
+"
+`;
+
+exports[`(6) This plugin doesn't support markdown parser, so it leaves Prettier's output as is. 1`] = `
+"\`\`\`tsx
+if (foo) {
+  bar();
+} else {
+  baz();
+}
+\`\`\`
+"
+`;

--- a/tests/v3-test/mdx/code-block/__snapshots__/allman.test.ts.snap
+++ b/tests/v3-test/mdx/code-block/__snapshots__/allman.test.ts.snap
@@ -1,0 +1,55 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`(1) This plugin doesn't support markdown parser, so it leaves Prettier's output as is. 1`] = `
+"\`\`\`jsx
+<div />
+\`\`\`
+"
+`;
+
+exports[`(2) This plugin doesn't support markdown parser, so it leaves Prettier's output as is. 1`] = `
+"\`\`\`jsx
+import foo from "foo";
+
+<div />;
+\`\`\`
+"
+`;
+
+exports[`(3) This plugin doesn't support markdown parser, so it leaves Prettier's output as is. 1`] = `
+"\`\`\`jsx
+if (foo) {
+  bar();
+} else {
+  baz();
+}
+\`\`\`
+"
+`;
+
+exports[`(4) This plugin doesn't support markdown parser, so it leaves Prettier's output as is. 1`] = `
+"\`\`\`tsx
+<div />
+\`\`\`
+"
+`;
+
+exports[`(5) This plugin doesn't support markdown parser, so it leaves Prettier's output as is. 1`] = `
+"\`\`\`tsx
+import foo from "foo";
+
+<div />;
+\`\`\`
+"
+`;
+
+exports[`(6) This plugin doesn't support markdown parser, so it leaves Prettier's output as is. 1`] = `
+"\`\`\`tsx
+if (foo) {
+  bar();
+} else {
+  baz();
+}
+\`\`\`
+"
+`;

--- a/tests/v3-test/mdx/code-block/__snapshots__/stroustrup.test.ts.snap
+++ b/tests/v3-test/mdx/code-block/__snapshots__/stroustrup.test.ts.snap
@@ -1,0 +1,55 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`(1) This plugin doesn't support markdown parser, so it leaves Prettier's output as is. 1`] = `
+"\`\`\`jsx
+<div />
+\`\`\`
+"
+`;
+
+exports[`(2) This plugin doesn't support markdown parser, so it leaves Prettier's output as is. 1`] = `
+"\`\`\`jsx
+import foo from "foo";
+
+<div />;
+\`\`\`
+"
+`;
+
+exports[`(3) This plugin doesn't support markdown parser, so it leaves Prettier's output as is. 1`] = `
+"\`\`\`jsx
+if (foo) {
+  bar();
+} else {
+  baz();
+}
+\`\`\`
+"
+`;
+
+exports[`(4) This plugin doesn't support markdown parser, so it leaves Prettier's output as is. 1`] = `
+"\`\`\`tsx
+<div />
+\`\`\`
+"
+`;
+
+exports[`(5) This plugin doesn't support markdown parser, so it leaves Prettier's output as is. 1`] = `
+"\`\`\`tsx
+import foo from "foo";
+
+<div />;
+\`\`\`
+"
+`;
+
+exports[`(6) This plugin doesn't support markdown parser, so it leaves Prettier's output as is. 1`] = `
+"\`\`\`tsx
+if (foo) {
+  bar();
+} else {
+  baz();
+}
+\`\`\`
+"
+`;

--- a/tests/v3-test/mdx/code-block/allman.test.ts
+++ b/tests/v3-test/mdx/code-block/allman.test.ts
@@ -1,0 +1,26 @@
+import { format } from 'prettier';
+import { baseOptions } from 'test-settings';
+import { expect, test } from 'vitest';
+
+// eslint-disable-next-line import/no-extraneous-dependencies
+import * as thisPlugin from '@/packages/v3-plugin';
+
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: [thisPlugin],
+  parser: 'mdx',
+  braceStyle: 'allman',
+};
+
+for (const fixture of fixtures) {
+  test(fixture.name, async () => {
+    expect(
+      await format(fixture.input, {
+        ...options,
+        ...(fixture.options ?? {}),
+      }),
+    ).toMatchSnapshot();
+  });
+}

--- a/tests/v3-test/mdx/code-block/fixtures.ts
+++ b/tests/v3-test/mdx/code-block/fixtures.ts
@@ -1,0 +1,62 @@
+import type { Fixture } from 'test-settings';
+
+export const fixtures: Omit<Fixture, 'output'>[] = [
+  {
+    name: "(1) This plugin doesn't support markdown parser, so it leaves Prettier's output as is.",
+    input: `
+\`\`\`jsx
+<div />;
+\`\`\`
+`,
+    options: {},
+  },
+  {
+    name: "(2) This plugin doesn't support markdown parser, so it leaves Prettier's output as is.",
+    input: `
+\`\`\`jsx
+import foo from 'foo'
+
+<div />
+\`\`\`
+`,
+    options: {},
+  },
+  {
+    name: "(3) This plugin doesn't support markdown parser, so it leaves Prettier's output as is.",
+    input: `
+\`\`\`jsx
+if (foo) { bar(); } else { baz(); }
+\`\`\`
+`,
+    options: {},
+  },
+  {
+    name: "(4) This plugin doesn't support markdown parser, so it leaves Prettier's output as is.",
+    input: `
+\`\`\`tsx
+<div />;
+\`\`\`
+`,
+    options: {},
+  },
+  {
+    name: "(5) This plugin doesn't support markdown parser, so it leaves Prettier's output as is.",
+    input: `
+\`\`\`tsx
+import foo from 'foo'
+
+<div />
+\`\`\`
+`,
+    options: {},
+  },
+  {
+    name: "(6) This plugin doesn't support markdown parser, so it leaves Prettier's output as is.",
+    input: `
+\`\`\`tsx
+if (foo) { bar(); } else { baz(); }
+\`\`\`
+`,
+    options: {},
+  },
+];

--- a/tests/v3-test/mdx/code-block/stroustrup.test.ts
+++ b/tests/v3-test/mdx/code-block/stroustrup.test.ts
@@ -1,0 +1,26 @@
+import { format } from 'prettier';
+import { baseOptions } from 'test-settings';
+import { expect, test } from 'vitest';
+
+// eslint-disable-next-line import/no-extraneous-dependencies
+import * as thisPlugin from '@/packages/v3-plugin';
+
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: [thisPlugin],
+  parser: 'mdx',
+  braceStyle: 'stroustrup',
+};
+
+for (const fixture of fixtures) {
+  test(fixture.name, async () => {
+    expect(
+      await format(fixture.input, {
+        ...options,
+        ...(fixture.options ?? {}),
+      }),
+    ).toMatchSnapshot();
+  });
+}


### PR DESCRIPTION
Refs: [prettier-plugin-classnames#82](https://github.com/ony3000/prettier-plugin-classnames/pull/82)