### PR TITLE
Support angular control flow blocks

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,8 +90,8 @@ importers:
         specifier: workspace:*
         version: link:../core-parts
       prettier:
-        specifier: 3.0.3
-        version: 3.0.3
+        specifier: 3.1.0
+        version: 3.1.0
 
   tests/test-settings:
     devDependencies:
@@ -126,14 +126,14 @@ importers:
   tests/v3-test:
     devDependencies:
       prettier:
-        specifier: 3.0.3
-        version: 3.0.3
+        specifier: 3.1.0
+        version: 3.1.0
       prettier-plugin-astro:
         specifier: 0.11.0
         version: 0.11.0
       prettier-plugin-svelte:
         specifier: 3.0.0
-        version: 3.0.0(prettier@3.0.3)(svelte@4.2.18)
+        version: 3.0.0(prettier@3.1.0)(svelte@4.2.18)
       test-settings:
         specifier: workspace:*
         version: link:../test-settings
@@ -2828,7 +2828,7 @@ packages:
     engines: {node: ^14.15.0 || >=16.0.0, pnpm: '>=7.14.0'}
     dependencies:
       '@astrojs/compiler': 1.8.2
-      prettier: 3.0.3
+      prettier: 3.1.0
       sass-formatter: 0.7.9
     dev: true
 
@@ -2842,13 +2842,13 @@ packages:
       svelte: 4.2.18
     dev: true
 
-  /prettier-plugin-svelte@3.0.0(prettier@3.0.3)(svelte@4.2.18):
+  /prettier-plugin-svelte@3.0.0(prettier@3.1.0)(svelte@4.2.18):
     resolution: {integrity: sha512-l3RQcPty2UBCoRh3yb9c5XCAmxkrc4BptAnbd5acO1gmSJtChOWkiEjnOvh7hvmtT4V80S8gXCOKAq8RNeIzSw==}
     peerDependencies:
       prettier: ^3.0.0
       svelte: ^3.2.0 || ^4.0.0-next.0
     dependencies:
-      prettier: 3.0.3
+      prettier: 3.1.0
       svelte: 4.2.18
     dev: true
 
@@ -2863,8 +2863,8 @@ packages:
     hasBin: true
     dev: true
 
-  /prettier@3.0.3:
-    resolution: {integrity: sha512-L/4pUDMxcNa8R/EthV08Zt42WBO4h1rarVtK0K+QJG0X187OLo7l699jWw0GKuwzkPQ//jMFA/8Xm6Fh3J/DAg==}
+  /prettier@3.1.0:
+    resolution: {integrity: sha512-TQLvXjq5IAibjh8EpBIkNKxO749UEWABoiIZehEPiY4GNpVdhaFKqSTu+QrlU6D2dPAfubRmtJTi4K4YkQ5eXw==}
     engines: {node: '>=14'}
     hasBin: true
 

--- a/src/packages/core-parts/finder.ts
+++ b/src/packages/core-parts/finder.ts
@@ -361,6 +361,67 @@ export function findTargetBraceNodesForHtml(
     };
 
     switch (node.type) {
+      case 'angularControlFlowBlock': {
+        nonCommentNodes.push(currentASTNode);
+
+        if (
+          isTypeof(
+            node,
+            z.object({
+              name: z.string(),
+              startSourceSpan: z.object({
+                end: z.object({
+                  offset: z.number(),
+                }),
+              }),
+              endSourceSpan: z.object({
+                start: z.object({
+                  offset: z.number(),
+                }),
+              }),
+            }),
+          )
+        ) {
+          switch (node.name) {
+            case 'defer':
+            case 'placeholder':
+            case 'loading':
+            case 'for':
+            case 'if':
+            case 'else if': {
+              braceNodes.push({
+                type: BraceType.OB,
+                range: [node.startSourceSpan.end.offset - 1, node.startSourceSpan.end.offset],
+              });
+              braceNodes.push({
+                type: BraceType.CB,
+                range: [node.endSourceSpan.start.offset, node.endSourceSpan.start.offset + 1],
+              });
+              break;
+            }
+            case 'error':
+            case 'empty':
+            case 'else':
+            case 'switch':
+            case 'case':
+            case 'default': {
+              braceNodes.push({
+                type: BraceType.OB,
+                range: [node.startSourceSpan.end.offset - 1, node.startSourceSpan.end.offset],
+              });
+              braceNodes.push({
+                type: BraceType.CBNT,
+                range: [node.endSourceSpan.start.offset, node.endSourceSpan.start.offset + 1],
+              });
+              break;
+            }
+            default: {
+              break;
+            }
+          }
+        }
+        break;
+      }
       case 'element': {
         nonCommentNodes.push(currentASTNode);
 

--- a/src/packages/v3-plugin/package.json
+++ b/src/packages/v3-plugin/package.json
@@ -6,6 +6,6 @@
   "license": "MIT",
   "dependencies": {
     "core-parts": "workspace:*",
-    "prettier": "3.0.3"
+    "prettier": "3.1.0"
   }
 }

--- a/tests/v3-test/angular/blocks/1tbs.test.ts
+++ b/tests/v3-test/angular/blocks/1tbs.test.ts
@@ -1,0 +1,26 @@
+import { format } from 'prettier';
+import { baseOptions } from 'test-settings';
+import { expect, test } from 'vitest';
+
+// eslint-disable-next-line import/no-extraneous-dependencies
+import * as thisPlugin from '@/packages/v3-plugin';
+
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: [thisPlugin],
+  parser: 'angular',
+  braceStyle: '1tbs',
+};
+
+for (const fixture of fixtures) {
+  test(fixture.name, async () => {
+    expect(
+      await format(fixture.input, {
+        ...options,
+        ...(fixture.options ?? {}),
+      }),
+    ).toMatchSnapshot();
+  });
+}

--- a/tests/v3-test/angular/blocks/__snapshots__/1tbs.test.ts.snap
+++ b/tests/v3-test/angular/blocks/__snapshots__/1tbs.test.ts.snap
@@ -1,0 +1,62 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`@defer block 1`] = `
+"@defer {
+  <large-component />
+} @placeholder {
+  <p>Placeholder</p>
+} @loading {
+  <img alt="loading image" src="loading.gif" />
+} @error {
+  <p>An loading error occurred</p>
+}
+"
+`;
+
+exports[`@defer block with triggers and parameters 1`] = `
+"@defer (on timer(500ms); prefetch on idle) {
+  <large-component />
+} @placeholder (minimum 500ms) {
+  <p>Placeholder</p>
+} @loading (after 100ms; minimum 1s) {
+  <img alt="loading image" src="loading.gif" />
+} @error {
+  <p>An loading error occurred</p>
+}
+"
+`;
+
+exports[`@for block 1`] = `
+"@for (item of items; track item.name) {
+  <li>{{ item.name }}</li>
+} @empty {
+  <li>There are no items.</li>
+}
+"
+`;
+
+exports[`@if block 1`] = `
+"@if (a > b) {
+  {{ a }} is greater than {{ b }}
+} @else if (b > a) {
+  {{ a }} is less than {{ b }}
+} @else {
+  {{ a }} is equal to {{ b }}
+}
+"
+`;
+
+exports[`@switch block 1`] = `
+"@switch (condition) {
+  @case (caseA) {
+    Case A.
+  }
+  @case (caseB) {
+    Case B.
+  }
+  @default {
+    Default case.
+  }
+}
+"
+`;

--- a/tests/v3-test/angular/blocks/__snapshots__/allman.test.ts.snap
+++ b/tests/v3-test/angular/blocks/__snapshots__/allman.test.ts.snap
@@ -1,0 +1,88 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`@defer block 1`] = `
+"@defer
+{
+  <large-component />
+}
+@placeholder
+{
+  <p>Placeholder</p>
+}
+@loading
+{
+  <img alt="loading image" src="loading.gif" />
+}
+@error
+{
+  <p>An loading error occurred</p>
+}
+"
+`;
+
+exports[`@defer block with triggers and parameters 1`] = `
+"@defer (on timer(500ms); prefetch on idle)
+{
+  <large-component />
+}
+@placeholder (minimum 500ms)
+{
+  <p>Placeholder</p>
+}
+@loading (after 100ms; minimum 1s)
+{
+  <img alt="loading image" src="loading.gif" />
+}
+@error
+{
+  <p>An loading error occurred</p>
+}
+"
+`;
+
+exports[`@for block 1`] = `
+"@for (item of items; track item.name)
+{
+  <li>{{ item.name }}</li>
+}
+@empty
+{
+  <li>There are no items.</li>
+}
+"
+`;
+
+exports[`@if block 1`] = `
+"@if (a > b)
+{
+  {{ a }} is greater than {{ b }}
+}
+@else if (b > a)
+{
+  {{ a }} is less than {{ b }}
+}
+@else
+{
+  {{ a }} is equal to {{ b }}
+}
+"
+`;
+
+exports[`@switch block 1`] = `
+"@switch (condition)
+{
+  @case (caseA)
+  {
+    Case A.
+  }
+  @case (caseB)
+  {
+    Case B.
+  }
+  @default
+  {
+    Default case.
+  }
+}
+"
+`;

--- a/tests/v3-test/angular/blocks/__snapshots__/stroustrup.test.ts.snap
+++ b/tests/v3-test/angular/blocks/__snapshots__/stroustrup.test.ts.snap
@@ -1,0 +1,71 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`@defer block 1`] = `
+"@defer {
+  <large-component />
+}
+@placeholder {
+  <p>Placeholder</p>
+}
+@loading {
+  <img alt="loading image" src="loading.gif" />
+}
+@error {
+  <p>An loading error occurred</p>
+}
+"
+`;
+
+exports[`@defer block with triggers and parameters 1`] = `
+"@defer (on timer(500ms); prefetch on idle) {
+  <large-component />
+}
+@placeholder (minimum 500ms) {
+  <p>Placeholder</p>
+}
+@loading (after 100ms; minimum 1s) {
+  <img alt="loading image" src="loading.gif" />
+}
+@error {
+  <p>An loading error occurred</p>
+}
+"
+`;
+
+exports[`@for block 1`] = `
+"@for (item of items; track item.name) {
+  <li>{{ item.name }}</li>
+}
+@empty {
+  <li>There are no items.</li>
+}
+"
+`;
+
+exports[`@if block 1`] = `
+"@if (a > b) {
+  {{ a }} is greater than {{ b }}
+}
+@else if (b > a) {
+  {{ a }} is less than {{ b }}
+}
+@else {
+  {{ a }} is equal to {{ b }}
+}
+"
+`;
+
+exports[`@switch block 1`] = `
+"@switch (condition) {
+  @case (caseA) {
+    Case A.
+  }
+  @case (caseB) {
+    Case B.
+  }
+  @default {
+    Default case.
+  }
+}
+"
+`;

--- a/tests/v3-test/angular/blocks/allman.test.ts
+++ b/tests/v3-test/angular/blocks/allman.test.ts
@@ -1,0 +1,26 @@
+import { format } from 'prettier';
+import { baseOptions } from 'test-settings';
+import { expect, test } from 'vitest';
+
+// eslint-disable-next-line import/no-extraneous-dependencies
+import * as thisPlugin from '@/packages/v3-plugin';
+
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: [thisPlugin],
+  parser: 'angular',
+  braceStyle: 'allman',
+};
+
+for (const fixture of fixtures) {
+  test(fixture.name, async () => {
+    expect(
+      await format(fixture.input, {
+        ...options,
+        ...(fixture.options ?? {}),
+      }),
+    ).toMatchSnapshot();
+  });
+}

--- a/tests/v3-test/angular/blocks/fixtures.ts
+++ b/tests/v3-test/angular/blocks/fixtures.ts
@@ -1,0 +1,70 @@
+import type { Fixture } from 'test-settings';
+
+export const fixtures: Omit<Fixture, 'output'>[] = [
+  {
+    name: '@defer block',
+    input: `
+@defer {
+  <large-component />
+} @placeholder {
+  <p>Placeholder</p>
+} @loading {
+  <img alt="loading image" src="loading.gif" />
+} @error {
+  <p>An loading error occurred</p>
+}
+`,
+  },
+  {
+    name: '@defer block with triggers and parameters',
+    input: `
+@defer (on timer(500ms); prefetch on idle) {
+  <large-component />
+} @placeholder (minimum 500ms) {
+  <p>Placeholder</p>
+} @loading (after 100ms; minimum 1s) {
+  <img alt="loading image" src="loading.gif" />
+} @error {
+  <p>An loading error occurred</p>
+}
+`,
+  },
+  {
+    name: '@for block',
+    input: `
+@for (item of items; track item.name) {
+  <li>{{ item.name }}</li>
+} @empty {
+  <li>There are no items.</li>
+}
+`,
+  },
+  {
+    name: '@if block',
+    input: `
+@if (a > b) {
+  {{a}} is greater than {{b}}
+} @else if (b > a) {
+  {{a}} is less than {{b}}
+} @else {
+  {{a}} is equal to {{b}}
+}
+`,
+  },
+  {
+    name: '@switch block',
+    input: `
+@switch (condition) {
+  @case (caseA) {
+    Case A.
+  }
+  @case (caseB) {
+    Case B.
+  }
+  @default {
+    Default case.
+  }
+}
+`,
+  },
+];

--- a/tests/v3-test/angular/blocks/stroustrup.test.ts
+++ b/tests/v3-test/angular/blocks/stroustrup.test.ts
@@ -1,0 +1,26 @@
+import { format } from 'prettier';
+import { baseOptions } from 'test-settings';
+import { expect, test } from 'vitest';
+
+// eslint-disable-next-line import/no-extraneous-dependencies
+import * as thisPlugin from '@/packages/v3-plugin';
+
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: [thisPlugin],
+  parser: 'angular',
+  braceStyle: 'stroustrup',
+};
+
+for (const fixture of fixtures) {
+  test(fixture.name, async () => {
+    expect(
+      await format(fixture.input, {
+        ...options,
+        ...(fixture.options ?? {}),
+      }),
+    ).toMatchSnapshot();
+  });
+}

--- a/tests/v3-test/package.json
+++ b/tests/v3-test/package.json
@@ -8,7 +8,7 @@
     "test": "vitest run --passWithNoTests"
   },
   "devDependencies": {
-    "prettier": "3.0.3",
+    "prettier": "3.1.0",
     "prettier-plugin-astro": "0.11.0",
     "prettier-plugin-svelte": "3.0.0",
     "test-settings": "workspace:*",


### PR DESCRIPTION
This PR closes #47.

Please note that [control flow block syntax is only supported in Prettier 3.1 and later](https://prettier.io/blog/2023/11/13/3.1.0.html#angular).