### PR TITLE
Find the correct parser by searching within the plugin.name property

### DIFF
--- a/src/parsers.ts
+++ b/src/parsers.ts
@@ -67,10 +67,9 @@ function transformParser(
 
       if (externalPluginName) {
         externalPlugin = plugins
-          .filter(
-            (plugin) =>
-              // @ts-expect-error: `name` is presumed to be injected internally by Prettier.
-              plugin.name === externalPluginName,
+          .filter((plugin) =>
+            // @ts-expect-error: `name` is presumed to be injected internally by Prettier.
+            plugin.name?.includes(externalPluginName),
           )
           .at(0);
 


### PR DESCRIPTION
Refs: [prettier-plugin-classnames#140](https://github.com/ony3000/prettier-plugin-classnames/issues/140)